### PR TITLE
docs: switch to `.list()` without arguments in examples

### DIFF
--- a/anthropic-java-example/src/main/java/com/anthropic/example/ModelListAsyncExample.java
+++ b/anthropic-java-example/src/main/java/com/anthropic/example/ModelListAsyncExample.java
@@ -3,7 +3,6 @@ package com.anthropic.example;
 import com.anthropic.client.AnthropicClientAsync;
 import com.anthropic.client.okhttp.AnthropicOkHttpClientAsync;
 import com.anthropic.models.ModelListPageAsync;
-import com.anthropic.models.ModelListParams;
 import java.util.concurrent.CompletableFuture;
 
 public final class ModelListAsyncExample {
@@ -13,9 +12,7 @@ public final class ModelListAsyncExample {
         // Configures using the `ANTHROPIC_API_KEY` environment variable
         AnthropicClientAsync client = AnthropicOkHttpClientAsync.fromEnv();
 
-        CompletableFuture<ModelListPageAsync> pageFuture =
-                // TODO: Update this example once we support `.list()` without arguments.
-                client.models().list(ModelListParams.builder().build());
+        CompletableFuture<ModelListPageAsync> pageFuture = client.models().list();
         pageFuture
                 .thenComposeAsync(page -> page.autoPager()
                         .forEach(

--- a/anthropic-java-example/src/main/java/com/anthropic/example/ModelListExample.java
+++ b/anthropic-java-example/src/main/java/com/anthropic/example/ModelListExample.java
@@ -2,7 +2,6 @@ package com.anthropic.example;
 
 import com.anthropic.client.AnthropicClient;
 import com.anthropic.client.okhttp.AnthropicOkHttpClient;
-import com.anthropic.models.ModelListParams;
 
 public final class ModelListExample {
     private ModelListExample() {}
@@ -11,10 +10,6 @@ public final class ModelListExample {
         // Configures using the `ANTHROPIC_API_KEY` environment variable
         AnthropicClient client = AnthropicOkHttpClient.fromEnv();
 
-        client.models()
-                // TODO: Update this example once we support `.list()` without arguments.
-                .list(ModelListParams.builder().build())
-                .autoPager()
-                .forEach(model -> System.out.println(model.id()));
+        client.models().list().autoPager().forEach(model -> System.out.println(model.id()));
     }
 }


### PR DESCRIPTION
Updated model().list() to support calls without arguments.