### PR TITLE
MessageAccumulator: First Draft

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,17 +278,22 @@ AnthropicClient client = AnthropicOkHttpClient.builder()
     .build();
 ```
 
-### Streaming Helpers
+### Streaming helpers
 
-The SDK provides conveniences for streamed messages. A `MessageAccumulator` can record the stream
-of events in the response as they are processed and accumulate a `Message` object similar to that
-which would have been returned by the non-streaming API.
+The SDK provides conveniences for streamed messages. A 
+[`MessageAccumulator`](anthropic-java-core/src/main/kotlin/com/anthropic/helpers/MessageAccumulator.kt)
+can record the stream of events in the response as they are processed and accumulate a 
+[`Message`](anthropic-java-core/src/main/kotlin/com/anthropic/models/messages/Message.kt) object
+similar to that which would have been returned by the non-streaming API.
 
-A `BetaMessageAccumulator` is also available for the accumulation of a `BetaMessage` object. It is
-used in the same manner as the `MessageAccumulator`.
+A [`BetaMessageAccumulator`](anthropic-java-core/src/main/kotlin/com/anthropic/helpers/BetaMessageAccumulator.kt)
+is also available for the accumulation of a
+[`BetaMessage`](anthropic-java-core/src/main/kotlin/com/anthropic/models/beta/messages/BetaMessage.kt)
+object. It is used in the same manner as the `MessageAccumulator`.
 
-For a synchronous response add a `Stream.peek()` call to the stream pipeline to accumulate each 
-event:
+For a synchronous response add a
+[`Stream.peek()`](https://docs.oracle.com/javase/8/docs/api/java/util/stream/Stream.html#peek-java.util.function.Consumer-)
+call to the stream pipeline to accumulate each event:
 
 ```java
 import com.anthropic.core.http.StreamResponse;
@@ -320,15 +325,13 @@ MessageAccumulator messageAccumulator = MessageAccumulator.create();
 
 client.messages()
         .createStreaming(createParams)
-        .subscribe(event -> 
-                messageAccumulator.accumulate(event).contentBlockDelta().stream()
+        .subscribe(event -> messageAccumulator.accumulate(event).contentBlockDelta().stream()
                 .flatMap(deltaEvent -> deltaEvent.delta().text().stream())
                 .forEach(textDelta -> System.out.print(textDelta.text())))
         .onCompleteFuture()
         .join();
 
 Message message = messageAccumulator.message();
-
 ```
 
 ## Raw responses

--- a/anthropic-java-core/src/main/kotlin/com/anthropic/helpers/BetaMessageAccumulator.kt
+++ b/anthropic-java-core/src/main/kotlin/com/anthropic/helpers/BetaMessageAccumulator.kt
@@ -185,6 +185,7 @@ class BetaMessageAccumulator private constructor() {
      * including the `message_stop` event, have been accumulated, the message can be retrieved by
      * calling [message].
      *
+     * @return The given [event] for convenience, such as when chaining method calls.
      * @throws AnthropicInvalidDataException If [accumulate] is called again after the final
      *   `message_stop` event has been accumulated. A [BetaMessageAccumulator] can only be used to
      *   accumulate a single [BetaMessage].
@@ -372,6 +373,7 @@ class BetaMessageAccumulator private constructor() {
                 }
             }
         )
+
         return event
     }
 

--- a/anthropic-java-core/src/main/kotlin/com/anthropic/helpers/MessageAccumulator.kt
+++ b/anthropic-java-core/src/main/kotlin/com/anthropic/helpers/MessageAccumulator.kt
@@ -183,6 +183,7 @@ class MessageAccumulator private constructor() {
      * the `message_stop` event, have been accumulated, the message can be retrieved by calling
      * [message].
      *
+     * @return The given [event] for convenience, such as when chaining method calls.
      * @throws AnthropicInvalidDataException If [accumulate] is called again after the final
      *   `message_stop` event has been accumulated. A [MessageAccumulator] can only be used to
      *   accumulate a single [Message].
@@ -360,6 +361,7 @@ class MessageAccumulator private constructor() {
                 }
             }
         )
+
         return event
     }
 

--- a/anthropic-java-core/src/main/kotlin/com/anthropic/helpers/MessageAccumulator.kt
+++ b/anthropic-java-core/src/main/kotlin/com/anthropic/helpers/MessageAccumulator.kt
@@ -1,0 +1,376 @@
+package com.anthropic.helpers
+
+import com.anthropic.core.JsonObject
+import com.anthropic.core.jsonMapper
+import com.anthropic.models.CitationCharLocation
+import com.anthropic.models.CitationContentBlockLocation
+import com.anthropic.models.CitationPageLocation
+import com.anthropic.models.CitationsDelta
+import com.anthropic.models.ContentBlock
+import com.anthropic.models.InputJsonDelta
+import com.anthropic.models.Message
+import com.anthropic.models.MessageDeltaUsage
+import com.anthropic.models.RawContentBlockDeltaEvent
+import com.anthropic.models.RawContentBlockStartEvent
+import com.anthropic.models.RawContentBlockStopEvent
+import com.anthropic.models.RawMessageDeltaEvent
+import com.anthropic.models.RawMessageStartEvent
+import com.anthropic.models.RawMessageStopEvent
+import com.anthropic.models.RawMessageStreamEvent
+import com.anthropic.models.RedactedThinkingBlock
+import com.anthropic.models.SignatureDelta
+import com.anthropic.models.TextBlock
+import com.anthropic.models.TextCitation
+import com.anthropic.models.TextDelta
+import com.anthropic.models.ThinkingBlock
+import com.anthropic.models.ThinkingDelta
+import com.anthropic.models.ToolUseBlock
+import com.anthropic.models.Usage
+
+/**
+ * An accumulator that constructs a [Message] from a sequence of streamed events. Pass all events
+ * from the `message_start` event to the `message_stop` event to [accumulate] and then call
+ * [message] to get the final accumulated message. The final [Message] will be similar to what would
+ * have been received had the non-streaming API been used.
+ *
+ * A [MessageAccumulator] may only be used to accumulate one message. To accumulate another message,
+ * create another instance of [MessageAccumulator].
+ */
+class MessageAccumulator {
+
+    // TODO: Confirm that the ubiquitous "_additionalProperties()" of the stream events can
+    //   generally be ignored and that it does not provide partial properties that need to be
+    //   accumulated.
+
+    /**
+     * The final accumulated message. Created from the [messageBuilder] when the `message_stop`
+     * event is notified.
+     */
+    private var message: Message? = null
+
+    /**
+     * The message builder used to accumulate the message details. Created when the `message_start`
+     * event is notified.
+     */
+    private var messageBuilder: Message.Builder? = null
+
+    /**
+     * The message usage that accumulates the details of input and output tokens used when creating
+     * the message. Created when the `message_start` event is notified.
+     */
+    // TODO: A "Message.Builder.appendUsage" function would be nice to have.
+    private var messageUsage: Usage? = null
+
+    /**
+     * The indexed collection of content blocks accumulated so far. As `content_block_delta` events
+     * are received, immutable elements here may be replaced with updated instances that hold the
+     * latest accumulation. The keys correspond to the `index` identified in each of the
+     * `content_block_delta` events.
+     */
+    private val messageContent: MutableMap<Long, ContentBlock> = mutableMapOf<Long, ContentBlock>()
+
+    /**
+     * Accumulations of partial JSON strings from `tool_use` content block deltas to form complete
+     * strings on the `content_block_stop` events, as valid JSON strings are required before each
+     * final `tool_use` content block can be created. Only on the `content_block_stop` events are
+     * such blocks created (based on the blocks from the `content_block_start` events); there are
+     * _no_ incremental updates to the starting content blocks as the `tool_use` delta events are
+     * notified. The keys correspond to the `index` identified in each of the `content_block_delta`
+     * events.
+     */
+    private val messageContentInputJson: MutableMap<Long, String> = mutableMapOf<Long, String>()
+
+    companion object {
+        private val JSON_MAPPER = jsonMapper()
+
+        internal fun mergeMessageUsage(usage: Usage, deltaUsage: MessageDeltaUsage): Usage =
+            usage.toBuilder().outputTokens(usage.outputTokens() + deltaUsage.outputTokens()).build()
+
+        internal fun mergeTextDelta(
+            contentBlock: ContentBlock,
+            textDelta: TextDelta,
+        ): ContentBlock {
+            require(contentBlock.isText()) { "Content block is not a text block." }
+            val oldTextBlock = contentBlock.text().get()
+            val newTextBlock =
+                TextBlock.builder()
+                    .from(oldTextBlock)
+                    .text(oldTextBlock.text() + textDelta.text())
+                    .build()
+
+            return ContentBlock.ofText(newTextBlock)
+        }
+
+        internal fun mergeCitationsDelta(
+            contentBlock: ContentBlock,
+            citationsDelta: CitationsDelta,
+        ): ContentBlock {
+            require(contentBlock.isText()) { "Content block is not a text block." }
+            val oldTextBlock = contentBlock.text().get()
+            val newTextBlock =
+                TextBlock.builder()
+                    .from(oldTextBlock)
+                    .addCitation(citationsDeltaToTextCitation(citationsDelta))
+                    .build()
+
+            return ContentBlock.ofText(newTextBlock)
+        }
+
+        internal fun mergeThinkingDelta(
+            contentBlock: ContentBlock,
+            thinkingDelta: ThinkingDelta,
+        ): ContentBlock {
+            require(contentBlock.isThinking()) { "Content block is not a thinking block." }
+            val oldThinkingBlock = contentBlock.thinking().get()
+            val newThinkingBlock =
+                ThinkingBlock.builder()
+                    .from(oldThinkingBlock)
+                    .thinking(oldThinkingBlock.thinking() + thinkingDelta.thinking())
+                    .build()
+
+            return ContentBlock.ofThinking(newThinkingBlock)
+        }
+
+        internal fun mergeSignatureDelta(
+            contentBlock: ContentBlock,
+            signatureDelta: SignatureDelta,
+        ): ContentBlock {
+            // Anthropic Streaming Messages API: "For thinking content, a special `signature_delta`
+            // event is sent just before the `content_block_stop` event. This signature is used to
+            // verify the integrity of the thinking block."
+            //
+            // Therefore, the "merge" here does not concatenate with the existing value of the
+            // `signature` on the `oldThinkingBlock`; the signature is simply set from the given
+            // `signatureDelta`, as there will be only one such delta for the content block.
+            require(contentBlock.isThinking()) { "Content block is not a thinking block." }
+            val oldThinkingBlock = contentBlock.thinking().get()
+            val newThinkingBlock =
+                ThinkingBlock.builder()
+                    .from(oldThinkingBlock)
+                    .signature(signatureDelta.signature())
+                    .build()
+
+            return ContentBlock.ofThinking(newThinkingBlock)
+        }
+
+        internal fun citationsDeltaToTextCitation(citationsDelta: CitationsDelta): TextCitation =
+            // A `CitationsDelta` only holds _one_ citation.
+            citationsDelta
+                .citation()
+                .accept(
+                    object : CitationsDelta.Citation.Visitor<TextCitation> {
+                        override fun visitCharLocation(
+                            charLocation: CitationCharLocation
+                        ): TextCitation = TextCitation.ofCitationCharLocation(charLocation)
+
+                        override fun visitPageLocation(
+                            pageLocation: CitationPageLocation
+                        ): TextCitation = TextCitation.ofCitationPageLocation(pageLocation)
+
+                        override fun visitContentBlockLocation(
+                            contentBlockLocation: CitationContentBlockLocation
+                        ): TextCitation =
+                            TextCitation.ofCitationContentBlockLocation(contentBlockLocation)
+                    }
+                )
+    }
+
+    /**
+     * Gets the final accumulated message. Until the `message_stop` event has been received, a
+     * message will not be available. Wait until all events have been handled by [accumulate] before
+     * calling this method.
+     *
+     * @throws IllegalStateException If called before the `message_stop` event has been accumulated.
+     */
+    // TODO: Decide to call this "finalMessage" or not. There is no concept of a "currentMessage"
+    //   (one partially accumulated), so a "final" prefix to the name seems redundant.
+    fun message(): Message =
+        message ?: throw IllegalStateException("'message_stop' event not yet received.")
+
+    /**
+     * Accumulates a streamed event and uses it to construct a [Message]. When all events, including
+     * the `message_stop` event, have been accumulated, the message can be retrieved by calling
+     * [message].
+     *
+     * @throws IllegalStateException If [accumulate] is called again after the final `message_stop`
+     *   event has been accumulated. A [MessageAccumulator] can only be used to accumulate a single
+     *   [Message].
+     */
+    fun accumulate(event: RawMessageStreamEvent): RawMessageStreamEvent {
+        check(message == null) { "'message_stop' event already received." }
+
+        event.accept(
+            object : RawMessageStreamEvent.Visitor<Unit> {
+                override fun visitStart(start: RawMessageStartEvent) {
+                    check(messageBuilder == null) { "'message_start' event already received." }
+                    messageBuilder = Message.Builder().from(start.message())
+                    messageUsage = start.message().usage()
+                }
+
+                override fun visitDelta(deltaEvent: RawMessageDeltaEvent) {
+                    val delta = deltaEvent.delta()
+
+                    // The Anthropic API allows that there may be "one or more `message_delta`
+                    // events". Here, the interpretation is that if multiple `message_delta` events
+                    // have a `stop_reason`, only the last encountered non-missing `stop_reason`
+                    // value will survive, which may be an _explicit_ `null` value.
+                    if (delta._stopReason().isNull()) {
+                        requireMessageBuilder().stopReason(null)
+                    } else if (!delta._stopReason().isMissing()) {
+                        requireMessageBuilder()
+                            .stopReason(Message.StopReason.of(delta.stopReason().get().asString()))
+                    }
+
+                    // The same applies to the `stop_sequence` string; only the last value will
+                    // survive; multiple `stop_sequence` string values from multiple events are
+                    // _not_ concatenated.
+                    if (delta._stopSequence().isNull()) {
+                        requireMessageBuilder().stopSequence(null)
+                    } else if (!delta._stopSequence().isMissing()) {
+                        requireMessageBuilder().stopSequence(delta.stopSequence().get())
+                    }
+
+                    messageUsage = mergeMessageUsage(requireMessageUsage(), deltaEvent.usage())
+                }
+
+                override fun visitStop(stop: RawMessageStopEvent) {
+                    message =
+                        requireMessageBuilder()
+                            // The indexed content block map is converted to a list with the blocks
+                            // in the indexed order. If there are gaps in the indexes, then the
+                            // indexes of the final list of content blocks will not correspond to
+                            // the indexes of the map entries. However, gaps are not expected and
+                            // what the event indexes were does not matter for the content blocks in
+                            // the final message; it only matters that the relative order of the
+                            // content blocks is preserved.
+                            .content(messageContent.entries.sortedBy { it.key }.map { it.value })
+                            .usage(requireMessageUsage())
+                            .build()
+                    messageBuilder = null
+                }
+
+                override fun visitContentBlockStart(contentBlockStart: RawContentBlockStartEvent) {
+                    val index = contentBlockStart.index()
+
+                    check(messageContent[index] == null) {
+                        "Content block already started for index $index."
+                    }
+
+                    contentBlockStart
+                        .contentBlock()
+                        .accept(
+                            object : RawContentBlockStartEvent.ContentBlock.Visitor<Unit> {
+                                override fun visitText(text: TextBlock) {
+                                    messageContent.put(index, ContentBlock.ofText(text))
+                                }
+
+                                override fun visitToolUse(toolUse: ToolUseBlock) {
+                                    messageContent.put(index, ContentBlock.ofToolUse(toolUse))
+                                }
+
+                                override fun visitThinking(thinking: ThinkingBlock) {
+                                    messageContent.put(index, ContentBlock.ofThinking(thinking))
+                                }
+
+                                override fun visitRedactedThinking(
+                                    redactedThinking: RedactedThinkingBlock
+                                ) {
+                                    // Anthropic Extended Thinking API specification:
+                                    // "`redacted_thinking` blocks will not have any deltas
+                                    // associated and will be sent as a single event."
+                                    messageContent.put(
+                                        index,
+                                        ContentBlock.ofRedactedThinking(redactedThinking),
+                                    )
+                                }
+                            }
+                        )
+                }
+
+                override fun visitContentBlockDelta(contentBlockDelta: RawContentBlockDeltaEvent) {
+                    val index = contentBlockDelta.index()
+                    val oldContentBlock = messageContent[index]
+
+                    check(oldContentBlock != null) { "Content block not started for index $index." }
+
+                    messageContent[index] =
+                        contentBlockDelta
+                            .delta()
+                            .accept(
+                                object : RawContentBlockDeltaEvent.Delta.Visitor<ContentBlock> {
+                                    override fun visitText(text: TextDelta): ContentBlock =
+                                        mergeTextDelta(oldContentBlock, text)
+
+                                    override fun visitInputJson(
+                                        inputJson: InputJsonDelta
+                                    ): ContentBlock {
+                                        val oldInputJson = messageContentInputJson[index]
+
+                                        messageContentInputJson[index] =
+                                            (oldInputJson ?: "") + inputJson.partialJson()
+
+                                        return oldContentBlock // Unchanged until stop event.
+                                    }
+
+                                    override fun visitCitations(
+                                        citations: CitationsDelta
+                                    ): ContentBlock =
+                                        mergeCitationsDelta(oldContentBlock, citations)
+
+                                    override fun visitThinking(
+                                        thinking: ThinkingDelta
+                                    ): ContentBlock = mergeThinkingDelta(oldContentBlock, thinking)
+
+                                    override fun visitSignature(
+                                        signature: SignatureDelta
+                                    ): ContentBlock =
+                                        mergeSignatureDelta(oldContentBlock, signature)
+                                }
+                            )
+                }
+
+                override fun visitContentBlockStop(contentBlockStop: RawContentBlockStopEvent) {
+                    val index = contentBlockStop.index()
+
+                    // Check only that there was a corresponding `content_block_start` event with
+                    // the same index as this `content_block_stop` event. There are no "subtypes" of
+                    // a `RawContentBlockStopEvent` as there are for the corresponding start and
+                    // delta events. It is not possible to validate that the `type` of this event is
+                    // the expected one for the accumulated content with the same `index`, as the
+                    // type is always just `content_block_stop`.
+                    val oldContentBlock = messageContent[index]
+                    check(oldContentBlock != null) { "Content block not started for index $index." }
+
+                    // The `content_block_stop` event for most content block types can be ignored,
+                    // as it carries no data. Where the `index` corresponds to a `tool_use` content
+                    // block, the partial JSON that was concatenated from each delta can now be used
+                    // to update the final `tool_use` content block.
+                    val inputJson = messageContentInputJson[index]
+
+                    if (oldContentBlock.isToolUse()) {
+                        // Check that there was at least one delta, so a potentially-valid `input`
+                        // JSON string was accumulated.
+                        check(inputJson != null) { "Missing input JSON for index $index." }
+                        messageContent[index] =
+                            ContentBlock.ofToolUse(
+                                oldContentBlock
+                                    .asToolUse()
+                                    .toBuilder()
+                                    // Anthropic Streaming Messages API: "the final `tool_use.input`
+                                    // is always an _object_."
+                                    .input(JSON_MAPPER.readValue(inputJson, JsonObject::class.java))
+                                    .build()
+                            )
+                    }
+                }
+            }
+        )
+        return event
+    }
+
+    private fun requireMessageBuilder(): Message.Builder =
+        messageBuilder ?: throw IllegalStateException("'message_start' event not received.")
+
+    private fun requireMessageUsage(): Usage =
+        messageUsage ?: throw IllegalStateException("'message_start' event not received.")
+}

--- a/anthropic-java-core/src/main/kotlin/com/anthropic/helpers/MessageAccumulator.kt
+++ b/anthropic-java-core/src/main/kotlin/com/anthropic/helpers/MessageAccumulator.kt
@@ -2,30 +2,30 @@ package com.anthropic.helpers
 
 import com.anthropic.core.JsonObject
 import com.anthropic.core.jsonMapper
-import com.anthropic.models.CitationCharLocation
-import com.anthropic.models.CitationContentBlockLocation
-import com.anthropic.models.CitationPageLocation
-import com.anthropic.models.CitationsDelta
-import com.anthropic.models.ContentBlock
-import com.anthropic.models.InputJsonDelta
-import com.anthropic.models.Message
-import com.anthropic.models.MessageDeltaUsage
-import com.anthropic.models.RawContentBlockDeltaEvent
-import com.anthropic.models.RawContentBlockStartEvent
-import com.anthropic.models.RawContentBlockStopEvent
-import com.anthropic.models.RawMessageDeltaEvent
-import com.anthropic.models.RawMessageStartEvent
-import com.anthropic.models.RawMessageStopEvent
-import com.anthropic.models.RawMessageStreamEvent
-import com.anthropic.models.RedactedThinkingBlock
-import com.anthropic.models.SignatureDelta
-import com.anthropic.models.TextBlock
-import com.anthropic.models.TextCitation
-import com.anthropic.models.TextDelta
-import com.anthropic.models.ThinkingBlock
-import com.anthropic.models.ThinkingDelta
-import com.anthropic.models.ToolUseBlock
-import com.anthropic.models.Usage
+import com.anthropic.models.messages.CitationCharLocation
+import com.anthropic.models.messages.CitationContentBlockLocation
+import com.anthropic.models.messages.CitationPageLocation
+import com.anthropic.models.messages.CitationsDelta
+import com.anthropic.models.messages.ContentBlock
+import com.anthropic.models.messages.InputJsonDelta
+import com.anthropic.models.messages.Message
+import com.anthropic.models.messages.MessageDeltaUsage
+import com.anthropic.models.messages.RawContentBlockDeltaEvent
+import com.anthropic.models.messages.RawContentBlockStartEvent
+import com.anthropic.models.messages.RawContentBlockStopEvent
+import com.anthropic.models.messages.RawMessageDeltaEvent
+import com.anthropic.models.messages.RawMessageStartEvent
+import com.anthropic.models.messages.RawMessageStopEvent
+import com.anthropic.models.messages.RawMessageStreamEvent
+import com.anthropic.models.messages.RedactedThinkingBlock
+import com.anthropic.models.messages.SignatureDelta
+import com.anthropic.models.messages.TextBlock
+import com.anthropic.models.messages.TextCitation
+import com.anthropic.models.messages.TextDelta
+import com.anthropic.models.messages.ThinkingBlock
+import com.anthropic.models.messages.ThinkingDelta
+import com.anthropic.models.messages.ToolUseBlock
+import com.anthropic.models.messages.Usage
 
 /**
  * An accumulator that constructs a [Message] from a sequence of streamed events. Pass all events

--- a/anthropic-java-core/src/test/kotlin/com/anthropic/helpers/MessageAccumulatorTest.kt
+++ b/anthropic-java-core/src/test/kotlin/com/anthropic/helpers/MessageAccumulatorTest.kt
@@ -4,32 +4,32 @@ import com.anthropic.core.JsonField
 import com.anthropic.core.JsonMissing
 import com.anthropic.core.JsonNull
 import com.anthropic.core.JsonString
-import com.anthropic.models.CitationCharLocation
-import com.anthropic.models.CitationContentBlockLocation
-import com.anthropic.models.CitationPageLocation
-import com.anthropic.models.CitationsDelta
-import com.anthropic.models.InputJsonDelta
-import com.anthropic.models.Message
-import com.anthropic.models.MessageDeltaUsage
-import com.anthropic.models.Model
-import com.anthropic.models.RawContentBlockDeltaEvent
-import com.anthropic.models.RawContentBlockStartEvent
-import com.anthropic.models.RawContentBlockStartEvent.ContentBlock
-import com.anthropic.models.RawContentBlockStopEvent
-import com.anthropic.models.RawMessageDeltaEvent
-import com.anthropic.models.RawMessageDeltaEvent.Delta.StopReason
-import com.anthropic.models.RawMessageStartEvent
-import com.anthropic.models.RawMessageStopEvent
-import com.anthropic.models.RawMessageStreamEvent
-import com.anthropic.models.RedactedThinkingBlock
-import com.anthropic.models.SignatureDelta
-import com.anthropic.models.TextBlock
-import com.anthropic.models.TextCitation
-import com.anthropic.models.TextDelta
-import com.anthropic.models.ThinkingBlock
-import com.anthropic.models.ThinkingDelta
-import com.anthropic.models.ToolUseBlock
-import com.anthropic.models.Usage
+import com.anthropic.models.messages.CitationCharLocation
+import com.anthropic.models.messages.CitationContentBlockLocation
+import com.anthropic.models.messages.CitationPageLocation
+import com.anthropic.models.messages.CitationsDelta
+import com.anthropic.models.messages.InputJsonDelta
+import com.anthropic.models.messages.Message
+import com.anthropic.models.messages.MessageDeltaUsage
+import com.anthropic.models.messages.Model
+import com.anthropic.models.messages.RawContentBlockDeltaEvent
+import com.anthropic.models.messages.RawContentBlockStartEvent
+import com.anthropic.models.messages.RawContentBlockStartEvent.ContentBlock
+import com.anthropic.models.messages.RawContentBlockStopEvent
+import com.anthropic.models.messages.RawMessageDeltaEvent
+import com.anthropic.models.messages.RawMessageDeltaEvent.Delta.StopReason
+import com.anthropic.models.messages.RawMessageStartEvent
+import com.anthropic.models.messages.RawMessageStopEvent
+import com.anthropic.models.messages.RawMessageStreamEvent
+import com.anthropic.models.messages.RedactedThinkingBlock
+import com.anthropic.models.messages.SignatureDelta
+import com.anthropic.models.messages.TextBlock
+import com.anthropic.models.messages.TextCitation
+import com.anthropic.models.messages.TextDelta
+import com.anthropic.models.messages.ThinkingBlock
+import com.anthropic.models.messages.ThinkingDelta
+import com.anthropic.models.messages.ToolUseBlock
+import com.anthropic.models.messages.Usage
 import kotlin.jvm.optionals.getOrNull
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatNoException
@@ -71,7 +71,7 @@ internal class MessageAccumulatorTest {
     fun mergeTextDeltaWrongBlockType() {
         assertThatThrownBy {
                 MessageAccumulator.mergeTextDelta(
-                    com.anthropic.models.ContentBlock.ofThinking(thinkingBlock()),
+                    com.anthropic.models.messages.ContentBlock.ofThinking(thinkingBlock()),
                     textDelta("hello"),
                 )
             }
@@ -85,7 +85,7 @@ internal class MessageAccumulatorTest {
         // (enough) that "Builder.from()" is being called to copy everything, not just the text.
         val text1 =
             MessageAccumulator.mergeTextDelta(
-                com.anthropic.models.ContentBlock.ofText(
+                com.anthropic.models.messages.ContentBlock.ofText(
                     textBlock("hello")
                         .toBuilder()
                         .addCitation(citationPageLocation(123L))
@@ -112,7 +112,7 @@ internal class MessageAccumulatorTest {
     fun mergeCitationsDeltaWrongBlockType() {
         assertThatThrownBy {
                 MessageAccumulator.mergeCitationsDelta(
-                    com.anthropic.models.ContentBlock.ofThinking(thinkingBlock()),
+                    com.anthropic.models.messages.ContentBlock.ofThinking(thinkingBlock()),
                     citationsDelta(123L),
                 )
             }
@@ -125,7 +125,7 @@ internal class MessageAccumulatorTest {
         // Use all types of citation to exercise the code in [citationsDeltaToTextCitation].
         val text1 =
             MessageAccumulator.mergeCitationsDelta(
-                com.anthropic.models.ContentBlock.ofText(textBlock("hello")),
+                com.anthropic.models.messages.ContentBlock.ofText(textBlock("hello")),
                 citationsDelta(123L),
             )
         val text2 = MessageAccumulator.mergeCitationsDelta(text1, citationsDelta(456L))
@@ -159,7 +159,7 @@ internal class MessageAccumulatorTest {
     fun mergeThinkingDeltaWrongBlockType() {
         assertThatThrownBy {
                 MessageAccumulator.mergeThinkingDelta(
-                    com.anthropic.models.ContentBlock.ofText(textBlock("hello")),
+                    com.anthropic.models.messages.ContentBlock.ofText(textBlock("hello")),
                     thinkingDelta("hmm...let me think..."),
                 )
             }
@@ -171,7 +171,7 @@ internal class MessageAccumulatorTest {
     fun mergeThinkingDelta() {
         val thinking1 =
             MessageAccumulator.mergeThinkingDelta(
-                com.anthropic.models.ContentBlock.ofThinking(
+                com.anthropic.models.messages.ContentBlock.ofThinking(
                     thinkingBlock("Let me see...", "sig-1")
                 ),
                 thinkingDelta(" Nope."),
@@ -193,7 +193,9 @@ internal class MessageAccumulatorTest {
     fun mergeSignatureDeltaWrongBlockType() {
         assertThatThrownBy {
                 MessageAccumulator.mergeSignatureDelta(
-                    com.anthropic.models.ContentBlock.ofText(textBlock("Yours sincerely,")),
+                    com.anthropic.models.messages.ContentBlock.ofText(
+                        textBlock("Yours sincerely,")
+                    ),
                     signatureDelta("John Hancock"),
                 )
             }
@@ -205,7 +207,9 @@ internal class MessageAccumulatorTest {
     fun mergeSignatureDelta() {
         val thinking1 =
             MessageAccumulator.mergeSignatureDelta(
-                com.anthropic.models.ContentBlock.ofThinking(thinkingBlock("Hmm...", "sig-1")),
+                com.anthropic.models.messages.ContentBlock.ofThinking(
+                    thinkingBlock("Hmm...", "sig-1")
+                ),
                 signatureDelta("sig-2"),
             )
         val thinking2 = MessageAccumulator.mergeSignatureDelta(thinking1, signatureDelta("sig-3"))
@@ -853,7 +857,10 @@ internal class MessageAccumulatorTest {
     ): RawMessageStreamEvent =
         contentBlockDeltaEvent(index, InputJsonDelta.builder().partialJson(partialJson).build())
 
-    private fun thinkingContentBlockStartEvent(index: Long, thinking: String = "[thought-1"): RawMessageStreamEvent =
+    private fun thinkingContentBlockStartEvent(
+        index: Long,
+        thinking: String = "[thought-1",
+    ): RawMessageStreamEvent =
         contentBlockStartEvent(
             index,
             ContentBlock.ofThinking(

--- a/anthropic-java-core/src/test/kotlin/com/anthropic/helpers/MessageAccumulatorTest.kt
+++ b/anthropic-java-core/src/test/kotlin/com/anthropic/helpers/MessageAccumulatorTest.kt
@@ -1,0 +1,989 @@
+package com.anthropic.helpers
+
+import com.anthropic.core.JsonField
+import com.anthropic.core.JsonMissing
+import com.anthropic.core.JsonNull
+import com.anthropic.core.JsonString
+import com.anthropic.models.CitationCharLocation
+import com.anthropic.models.CitationContentBlockLocation
+import com.anthropic.models.CitationPageLocation
+import com.anthropic.models.CitationsDelta
+import com.anthropic.models.InputJsonDelta
+import com.anthropic.models.Message
+import com.anthropic.models.MessageDeltaUsage
+import com.anthropic.models.Model
+import com.anthropic.models.RawContentBlockDeltaEvent
+import com.anthropic.models.RawContentBlockStartEvent
+import com.anthropic.models.RawContentBlockStartEvent.ContentBlock
+import com.anthropic.models.RawContentBlockStopEvent
+import com.anthropic.models.RawMessageDeltaEvent
+import com.anthropic.models.RawMessageDeltaEvent.Delta.StopReason
+import com.anthropic.models.RawMessageStartEvent
+import com.anthropic.models.RawMessageStopEvent
+import com.anthropic.models.RawMessageStreamEvent
+import com.anthropic.models.RedactedThinkingBlock
+import com.anthropic.models.SignatureDelta
+import com.anthropic.models.TextBlock
+import com.anthropic.models.TextCitation
+import com.anthropic.models.TextDelta
+import com.anthropic.models.ThinkingBlock
+import com.anthropic.models.ThinkingDelta
+import com.anthropic.models.ToolUseBlock
+import com.anthropic.models.Usage
+import kotlin.jvm.optionals.getOrNull
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatNoException
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+internal class MessageAccumulatorTest {
+    companion object {
+        private const val INPUT_TOKENS: Long = 42L
+
+        /** A value that is "not set" has no effect on any existing value when accumulated. */
+        private val NOT_SET = JsonMissing.of()
+
+        /** A value that is "set to null" resets any existing value to `null` when accumulated. */
+        private val SET_TO_NULL = JsonNull.of()
+    }
+
+    @Test
+    fun mergeMessageUsage() {
+        val usage1 =
+            MessageAccumulator.mergeMessageUsage(
+                usage(INPUT_TOKENS),
+                MessageDeltaUsage.builder().outputTokens(44L).build(),
+            )
+        val usage2 =
+            MessageAccumulator.mergeMessageUsage(
+                usage1,
+                MessageDeltaUsage.builder().outputTokens(11L).build(),
+            )
+
+        assertThat(usage1.inputTokens()).isEqualTo(INPUT_TOKENS)
+        assertThat(usage1.outputTokens()).isEqualTo(44L)
+
+        assertThat(usage2.inputTokens()).isEqualTo(INPUT_TOKENS)
+        assertThat(usage2.outputTokens()).isEqualTo(44L + 11L)
+    }
+
+    @Test
+    fun mergeTextDeltaWrongBlockType() {
+        assertThatThrownBy {
+                MessageAccumulator.mergeTextDelta(
+                    com.anthropic.models.ContentBlock.ofThinking(thinkingBlock()),
+                    textDelta("hello"),
+                )
+            }
+            .isExactlyInstanceOf(IllegalArgumentException::class.java)
+            .hasMessage("Content block is not a text block.")
+    }
+
+    @Test
+    fun mergeTextDelta() {
+        // Add citations and later check they are preserved by the "merge" operation. This proves
+        // (enough) that "Builder.from()" is being called to copy everything, not just the text.
+        val text1 =
+            MessageAccumulator.mergeTextDelta(
+                com.anthropic.models.ContentBlock.ofText(
+                    textBlock("hello")
+                        .toBuilder()
+                        .addCitation(citationPageLocation(123L))
+                        .addCitation(citationPageLocation(456L))
+                        .build()
+                ),
+                textDelta(" world"),
+            )
+        val text2 = MessageAccumulator.mergeTextDelta(text1, textDelta("!!!"))
+        val citations2 = text2.asText().citations().get()
+
+        assertThat(text1.isText()).isTrue()
+        assertThat(text1.text().get().text()).isEqualTo("hello world")
+
+        assertThat(text2.isText()).isTrue()
+        assertThat(text2.text().get().text()).isEqualTo("hello world!!!")
+
+        assertThat(citations2.size).isEqualTo(2)
+        assertThat(citations2[0].citationPageLocation().get().startPageNumber()).isEqualTo(123L)
+        assertThat(citations2[1].citationPageLocation().get().startPageNumber()).isEqualTo(456L)
+    }
+
+    @Test
+    fun mergeCitationsDeltaWrongBlockType() {
+        assertThatThrownBy {
+                MessageAccumulator.mergeCitationsDelta(
+                    com.anthropic.models.ContentBlock.ofThinking(thinkingBlock()),
+                    citationsDelta(123L),
+                )
+            }
+            .isExactlyInstanceOf(IllegalArgumentException::class.java)
+            .hasMessage("Content block is not a text block.")
+    }
+
+    @Test
+    fun mergeCitationsDelta() {
+        // Use all types of citation to exercise the code in [citationsDeltaToTextCitation].
+        val text1 =
+            MessageAccumulator.mergeCitationsDelta(
+                com.anthropic.models.ContentBlock.ofText(textBlock("hello")),
+                citationsDelta(123L),
+            )
+        val text2 = MessageAccumulator.mergeCitationsDelta(text1, citationsDelta(456L))
+        val text3 =
+            MessageAccumulator.mergeCitationsDelta(
+                text2,
+                CitationsDelta.builder().citation(citationCharLocation(789L)).build(),
+            )
+        val text4 =
+            MessageAccumulator.mergeCitationsDelta(
+                text3,
+                CitationsDelta.builder().citation(citationContentBlockLocation(890L)).build(),
+            )
+        val citations4 = text4.asText().citations().get()
+
+        assertThat(text1.isText()).isTrue()
+        assertThat(text1.text().get().text()).isEqualTo("hello")
+
+        assertThat(text2.isText()).isTrue()
+        assertThat(text2.text().get().text()).isEqualTo("hello")
+
+        assertThat(citations4.size).isEqualTo(4)
+        assertThat(citations4[0].citationPageLocation().get().startPageNumber()).isEqualTo(123L)
+        assertThat(citations4[1].citationPageLocation().get().startPageNumber()).isEqualTo(456L)
+        assertThat(citations4[2].citationCharLocation().get().startCharIndex()).isEqualTo(789L)
+        assertThat(citations4[3].citationContentBlockLocation().get().startBlockIndex())
+            .isEqualTo(890L)
+    }
+
+    @Test
+    fun mergeThinkingDeltaWrongBlockType() {
+        assertThatThrownBy {
+                MessageAccumulator.mergeThinkingDelta(
+                    com.anthropic.models.ContentBlock.ofText(textBlock("hello")),
+                    thinkingDelta("hmm...let me think..."),
+                )
+            }
+            .isExactlyInstanceOf(IllegalArgumentException::class.java)
+            .hasMessage("Content block is not a thinking block.")
+    }
+
+    @Test
+    fun mergeThinkingDelta() {
+        val thinking1 =
+            MessageAccumulator.mergeThinkingDelta(
+                com.anthropic.models.ContentBlock.ofThinking(
+                    thinkingBlock("Let me see...", "sig-1")
+                ),
+                thinkingDelta(" Nope."),
+            )
+        val thinking2 =
+            MessageAccumulator.mergeThinkingDelta(thinking1, thinkingDelta(" Not a clue."))
+
+        assertThat(thinking1.isThinking()).isTrue()
+        assertThat(thinking1.thinking().get().thinking()).isEqualTo("Let me see... Nope.")
+
+        assertThat(thinking2.isThinking()).isTrue()
+        assertThat(thinking2.thinking().get().thinking())
+            .isEqualTo("Let me see... Nope. Not a clue.")
+
+        assertThat(thinking2.thinking().get().signature()).isEqualTo("sig-1")
+    }
+
+    @Test
+    fun mergeSignatureDeltaWrongBlockType() {
+        assertThatThrownBy {
+                MessageAccumulator.mergeSignatureDelta(
+                    com.anthropic.models.ContentBlock.ofText(textBlock("Yours sincerely,")),
+                    signatureDelta("John Hancock"),
+                )
+            }
+            .isExactlyInstanceOf(IllegalArgumentException::class.java)
+            .hasMessage("Content block is not a thinking block.")
+    }
+
+    @Test
+    fun mergeSignatureDelta() {
+        val thinking1 =
+            MessageAccumulator.mergeSignatureDelta(
+                com.anthropic.models.ContentBlock.ofThinking(thinkingBlock("Hmm...", "sig-1")),
+                signatureDelta("sig-2"),
+            )
+        val thinking2 = MessageAccumulator.mergeSignatureDelta(thinking1, signatureDelta("sig-3"))
+
+        assertThat(thinking1.isThinking()).isTrue()
+        assertThat(thinking1.thinking().get().thinking()).isEqualTo("Hmm...")
+        // Signatures are not concatenated. The last signature delta is used as the only signature.
+        assertThat(thinking1.thinking().get().signature()).isEqualTo("sig-2")
+
+        assertThat(thinking2.isThinking()).isTrue()
+        assertThat(thinking2.thinking().get().thinking()).isEqualTo("Hmm...")
+        assertThat(thinking2.thinking().get().signature()).isEqualTo("sig-3")
+    }
+
+    @Test
+    fun messageNotStarted() {
+        val accumulator = MessageAccumulator()
+
+        assertThatThrownBy { accumulator.message() }
+            .isExactlyInstanceOf(IllegalStateException::class.java)
+            .hasMessage("'message_stop' event not yet received.")
+    }
+
+    @Test
+    fun messageNotStopped() {
+        val accumulator = MessageAccumulator()
+
+        accumulator.accumulate(messageStartEvent())
+
+        assertThatThrownBy { accumulator.message() }
+            .isExactlyInstanceOf(IllegalStateException::class.java)
+            .hasMessage("'message_stop' event not yet received.")
+    }
+
+    @Test
+    fun accumulateStopEventBeforeStarted() {
+        val accumulator = MessageAccumulator()
+
+        assertThatThrownBy { accumulator.accumulate(messageStopEvent()) }
+            .isExactlyInstanceOf(IllegalStateException::class.java)
+            .hasMessage("'message_start' event not received.")
+    }
+
+    @Test
+    fun accumulateDeltaEventBeforeStarted() {
+        val accumulator = MessageAccumulator()
+
+        assertThatThrownBy { accumulator.accumulate(messageDeltaEvent()) }
+            .isExactlyInstanceOf(IllegalStateException::class.java)
+            .hasMessage("'message_start' event not received.")
+    }
+
+    @Test
+    fun accumulateStartEventAfterStart() {
+        val accumulator = MessageAccumulator()
+
+        accumulator.accumulate(messageStartEvent())
+
+        assertThatThrownBy { accumulator.accumulate(messageStartEvent()) }
+            .isExactlyInstanceOf(IllegalStateException::class.java)
+            .hasMessage("'message_start' event already received.")
+    }
+
+    @Test
+    fun accumulateStopEventAfterStopped() {
+        val accumulator = MessageAccumulator()
+
+        accumulator.accumulate(messageStartEvent())
+        accumulator.accumulate(messageStopEvent())
+
+        assertThatThrownBy { accumulator.accumulate(messageStopEvent()) }
+            .isExactlyInstanceOf(IllegalStateException::class.java)
+            .hasMessage("'message_stop' event already received.")
+    }
+
+    @Test
+    fun accumulateStartEventAfterStopped() {
+        val accumulator = MessageAccumulator()
+
+        accumulator.accumulate(messageStartEvent())
+        accumulator.accumulate(messageStopEvent())
+
+        assertThatThrownBy { accumulator.accumulate(messageStartEvent()) }
+            .isExactlyInstanceOf(IllegalStateException::class.java)
+            .hasMessage("'message_stop' event already received.")
+    }
+
+    @Test
+    fun accumulateDeltaEventAfterStopped() {
+        val accumulator = MessageAccumulator()
+
+        accumulator.accumulate(messageStartEvent())
+        accumulator.accumulate(messageStopEvent())
+
+        assertThatThrownBy { accumulator.accumulate(messageDeltaEvent()) }
+            .isExactlyInstanceOf(IllegalStateException::class.java)
+            .hasMessage("'message_stop' event already received.")
+    }
+
+    @Test
+    fun messageWithNoDeltasOrContent() {
+        val accumulator = MessageAccumulator()
+
+        accumulator.accumulate(messageStartEvent())
+        accumulator.accumulate(messageStopEvent())
+
+        assertThatNoException().isThrownBy { accumulator.message() }
+
+        val message = accumulator.message()
+
+        assertThat(message.id()).isEqualTo("message-id")
+        assertThat(message.model()).isEqualTo(Model.CLAUDE_3_5_SONNET_LATEST)
+
+        assertThat(message.content()).isEmpty()
+
+        assertThat(message.stopReason()).isNotPresent()
+        assertThat(message.stopSequence()).isNotPresent()
+
+        assertThat(message.usage().inputTokens()).isEqualTo(INPUT_TOKENS)
+        assertThat(message.usage().cacheCreationInputTokens()).hasValue(0L)
+        assertThat(message.usage().cacheReadInputTokens()).hasValue(0L)
+        assertThat(message.usage().outputTokens()).isEqualTo(0L)
+    }
+
+    @Test
+    fun messageWithDeltasAndNoContent() {
+        val accumulator = MessageAccumulator()
+
+        accumulator.accumulate(messageStartEvent())
+        accumulator.accumulate(
+            messageDeltaEvent(JsonField.of(StopReason.END_TURN), outputTokens = 96L)
+        )
+        accumulator.accumulate(messageStopEvent())
+
+        assertThatNoException().isThrownBy { accumulator.message() }
+
+        val message = accumulator.message()
+
+        assertThat(message.id()).isEqualTo("message-id")
+        assertThat(message.model()).isEqualTo(Model.CLAUDE_3_5_SONNET_LATEST)
+
+        assertThat(message.content()).isEmpty()
+
+        assertThat(message.stopReason()).isPresent()
+        // "Message.StopReason" and "RawMessageDeltaEvent.Delta.StopReason" are not the same thing!
+        assertThat(message.stopReason().get()).isEqualTo(Message.StopReason.END_TURN)
+
+        assertThat(message.stopSequence()).isNotPresent()
+
+        assertThat(message.usage().inputTokens()).isEqualTo(INPUT_TOKENS)
+        assertThat(message.usage().cacheCreationInputTokens()).hasValue(0L)
+        assertThat(message.usage().cacheReadInputTokens()).hasValue(0L)
+        assertThat(message.usage().outputTokens()).isEqualTo(96L)
+    }
+
+    @Test
+    fun messageStopReasonDefaultsToMissing() {
+        val accumulator = MessageAccumulator()
+
+        accumulator.accumulate(messageStartEvent())
+        accumulator.accumulate(messageStopEvent())
+
+        // Check both the non-public "raw" JSON value and the public `Optional` value (which will
+        // be `null` if the "raw" value is missing).
+        assertThat(accumulator.message()._stopReason().isMissing()).isEqualTo(true)
+        assertThat(accumulator.message().stopReason().getOrNull()).isNull()
+    }
+
+    @Test
+    fun messageDeltaWithNullStopReason() {
+        // The default stop reason is `JsonMissing`. See if an explicit `null` works instead and
+        // that an explicit `JsonMissing` does not override the `null`.
+        val accumulator = MessageAccumulator()
+
+        accumulator.accumulate(messageStartEvent())
+        accumulator.accumulate(messageDeltaEvent(stopReason = SET_TO_NULL))
+        accumulator.accumulate(messageDeltaEvent(stopReason = NOT_SET)) // Should be ignored.
+        accumulator.accumulate(messageStopEvent())
+
+        assertThat(accumulator.message()._stopReason().isMissing()).isEqualTo(false)
+        assertThat(accumulator.message()._stopReason().isNull()).isEqualTo(true)
+        assertThat(accumulator.message().stopReason().getOrNull()).isNull()
+    }
+
+    @Test
+    fun messageDeltaWithNonNullStopReason() {
+        val accumulator = MessageAccumulator()
+
+        accumulator.accumulate(messageStartEvent())
+        // The last non-missing value should "win".
+        accumulator.accumulate(messageDeltaEvent(stopReason = SET_TO_NULL))
+        accumulator.accumulate(messageDeltaEvent(stopReason = NOT_SET)) // Should be ignored.
+        accumulator.accumulate(messageDeltaEvent(stopReason = JsonField.of(StopReason.END_TURN)))
+        accumulator.accumulate(messageStopEvent())
+
+        assertThat(accumulator.message()._stopReason().isMissing()).isEqualTo(false)
+        assertThat(accumulator.message()._stopReason().isNull()).isEqualTo(false)
+        assertThat(accumulator.message().stopReason().get()).isEqualTo(Message.StopReason.END_TURN)
+    }
+
+    @Test
+    fun messageStopSequenceDefaultsToMissing() {
+        val accumulator = MessageAccumulator()
+
+        accumulator.accumulate(messageStartEvent())
+        accumulator.accumulate(messageStopEvent())
+
+        // Check both the non-public "raw" JSON value and the public `Optional` value (which will
+        // be `null` if the "raw" value is missing).
+        assertThat(accumulator.message()._stopSequence().isMissing()).isEqualTo(true)
+        assertThat(accumulator.message().stopSequence().getOrNull()).isNull()
+    }
+
+    @Test
+    fun messageDeltaWithNullStopSequence() {
+        // The default stop sequence is `JsonMissing`. See if an explicit `null` works instead and
+        // that an explicit `JsonMissing` does not override the `null`.
+        val accumulator = MessageAccumulator()
+
+        accumulator.accumulate(messageStartEvent())
+        accumulator.accumulate(messageDeltaEvent(stopSequence = SET_TO_NULL))
+        accumulator.accumulate(messageDeltaEvent(stopSequence = NOT_SET)) // Should be ignored.
+        accumulator.accumulate(messageStopEvent())
+
+        assertThat(accumulator.message()._stopSequence().isMissing()).isEqualTo(false)
+        assertThat(accumulator.message()._stopSequence().isNull()).isEqualTo(true)
+        assertThat(accumulator.message().stopSequence().getOrNull()).isNull()
+    }
+
+    @Test
+    fun messageDeltaWithNonNullStopSequence() {
+        val accumulator = MessageAccumulator()
+
+        accumulator.accumulate(messageStartEvent())
+        // The last non-missing value should "win".
+        accumulator.accumulate(messageDeltaEvent(stopSequence = SET_TO_NULL))
+        accumulator.accumulate(messageDeltaEvent(stopSequence = NOT_SET)) // Should be ignored.
+        accumulator.accumulate(messageDeltaEvent(stopSequence = JsonField.of("hello world")))
+        accumulator.accumulate(messageStopEvent())
+
+        assertThat(accumulator.message()._stopSequence().isMissing()).isEqualTo(false)
+        assertThat(accumulator.message()._stopSequence().isNull()).isEqualTo(false)
+        assertThat(accumulator.message().stopSequence().get()).isEqualTo("hello world")
+    }
+
+    @Test
+    fun messageDeltaWithUsage() {
+        val accumulator = MessageAccumulator()
+
+        accumulator.accumulate(messageStartEvent())
+        accumulator.accumulate(messageDeltaEvent(outputTokens = 11L))
+        accumulator.accumulate(messageDeltaEvent(outputTokens = 12L))
+        accumulator.accumulate(messageDeltaEvent(outputTokens = 13L))
+        accumulator.accumulate(messageStopEvent())
+
+        assertThat(accumulator.message().usage().inputTokens()).isEqualTo(INPUT_TOKENS)
+        assertThat(accumulator.message().usage().outputTokens()).isEqualTo(11L + 12L + 13L)
+    }
+
+    @Test
+    fun accumulateContentBlocksWithDuplicateIndexes() {
+        val accumulator = MessageAccumulator()
+
+        accumulator.accumulate(messageStartEvent())
+        accumulator.accumulate(textContentBlockStartEvent(0L, "0-ONE."))
+        accumulator.accumulate(textContentBlockStartEvent(1L, "1-ONE."))
+        accumulator.accumulate(textContentBlockDeltaEvent(0L, "0-TWO."))
+
+        assertThatThrownBy { accumulator.accumulate(textContentBlockStartEvent(0L, "0-ONE.")) }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessage("Content block already started for index 0.")
+    }
+
+    @Test
+    fun accumulateContentBlocksStopWithoutStart() {
+        val accumulator = MessageAccumulator()
+
+        accumulator.accumulate(messageStartEvent())
+        accumulator.accumulate(textContentBlockStartEvent(0L, "0-ONE."))
+
+        assertThatThrownBy { accumulator.accumulate(contentBlockStopEvent(1L)) }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessage("Content block not started for index 1.")
+    }
+
+    @Test
+    fun accumulateContentBlocksDeltaWithoutStart() {
+        val accumulator = MessageAccumulator()
+
+        accumulator.accumulate(messageStartEvent())
+        accumulator.accumulate(textContentBlockStartEvent(0L, "0-ONE."))
+
+        assertThatThrownBy { accumulator.accumulate(textContentBlockDeltaEvent(1L, "1-TWO.")) }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessage("Content block not started for index 1.")
+    }
+
+    @Test
+    fun accumulateTextContentBlockWithTextDeltasAndCitationsDeltas() {
+        val accumulator = MessageAccumulator()
+
+        accumulator.accumulate(messageStartEvent())
+
+        // Deliberately use non-zero-based and non-consecutive indexes and start the blocks out of
+        // order. In the final message there should be two blocks in the indexed order, but using
+        // indexes 0 and 1. While this might not be realistic, it should demonstrate the tolerance
+        // of the implementation for indexes arriving out-of-order and having gaps.
+        accumulator.accumulate(textContentBlockStartEvent(3L, "3-ONE."))
+        accumulator.accumulate(textContentBlockStartEvent(1L, "1-ONE.", 987L))
+
+        accumulator.accumulate(textContentBlockDeltaEvent(1L, "1-TWO."))
+        accumulator.accumulate(textContentBlockDeltaEvent(3L, "3-TWO."))
+
+        accumulator.accumulate(citationContentBlockDeltaEvent(3L, 234L))
+        accumulator.accumulate(textContentBlockDeltaEvent(3L, "3-THREE."))
+        accumulator.accumulate(citationContentBlockDeltaEvent(3L, 123L))
+
+        accumulator.accumulate(textContentBlockDeltaEvent(1L, "1-THREE."))
+        accumulator.accumulate(citationContentBlockDeltaEvent(1L, 654L))
+
+        accumulator.accumulate(contentBlockStopEvent(3L))
+        accumulator.accumulate(contentBlockStopEvent(1L))
+
+        accumulator.accumulate(
+            messageDeltaEvent(stopReason = JsonField.of(StopReason.END_TURN), outputTokens = 99L)
+        )
+        accumulator.accumulate(messageStopEvent())
+
+        val message = accumulator.message()
+        val content = message.content()
+
+        assertThat(message.stopSequence().getOrNull()).isNull()
+        assertThat(message.stopReason().get()).isEqualTo(Message.StopReason.END_TURN)
+        assertThat(message.usage().inputTokens()).isEqualTo(INPUT_TOKENS)
+        assertThat(message.usage().outputTokens()).isEqualTo(99L)
+
+        assertThat(content.size).isEqualTo(2)
+        assertThat(content[0].asText().text()).isEqualTo("1-ONE.1-TWO.1-THREE.")
+        assertThat(content[0].asText().citations().get())
+            .isEqualTo(listOf(textCitation(987L), textCitation(654L)))
+
+        assertThat(content[1].asText().text()).isEqualTo("3-ONE.3-TWO.3-THREE.")
+        assertThat(content[1].asText().citations().get())
+            .isEqualTo(listOf(textCitation(234L), textCitation(123L)))
+    }
+
+    @Test
+    fun accumulateTextAndToolUseContentBlocks() {
+        val accumulator = MessageAccumulator()
+
+        accumulator.accumulate(messageStartEvent())
+
+        accumulator.accumulate(textContentBlockStartEvent(3L, "3-ONE."))
+        accumulator.accumulate(toolUseContentBlockStartEvent(1L, "1-TOOL."))
+
+        // Tool use content block deltas will build up the JSON string: {"hello":"world"}
+        accumulator.accumulate(toolUseContentBlockDeltaEvent(1L, "{\"hel"))
+        accumulator.accumulate(textContentBlockDeltaEvent(3L, "3-TWO."))
+
+        accumulator.accumulate(citationContentBlockDeltaEvent(3L, 234L))
+        accumulator.accumulate(toolUseContentBlockDeltaEvent(1L, "lo\":\"wo"))
+        accumulator.accumulate(textContentBlockDeltaEvent(3L, "3-THREE."))
+
+        accumulator.accumulate(toolUseContentBlockDeltaEvent(1L, "rld\"}"))
+
+        accumulator.accumulate(contentBlockStopEvent(3L))
+        accumulator.accumulate(contentBlockStopEvent(1L))
+
+        accumulator.accumulate(
+            messageDeltaEvent(stopReason = JsonField.of(StopReason.TOOL_USE), outputTokens = 88L)
+        )
+        accumulator.accumulate(messageStopEvent())
+
+        val message = accumulator.message()
+        val content = message.content()
+
+        assertThat(message.stopSequence().getOrNull()).isNull()
+        assertThat(message.stopReason().get()).isEqualTo(Message.StopReason.TOOL_USE)
+        assertThat(message.usage().inputTokens()).isEqualTo(INPUT_TOKENS)
+        assertThat(message.usage().outputTokens()).isEqualTo(88L)
+
+        assertThat(content.size).isEqualTo(2)
+        assertThat(content[0].asToolUse().name()).isEqualTo("1-TOOL.")
+        assertThat(content[0].asToolUse()._input().asObject().get()["hello"])
+            .isEqualTo(JsonString.of("world"))
+
+        assertThat(content[1].asText().text()).isEqualTo("3-ONE.3-TWO.3-THREE.")
+        assertThat(content[1].asText().citations().get()).isEqualTo(listOf(textCitation(234L)))
+    }
+
+    @Test
+    fun accumulateThinkingAndTextContentBlocks() {
+        val accumulator = MessageAccumulator()
+
+        accumulator.accumulate(messageStartEvent())
+
+        accumulator.accumulate(textContentBlockStartEvent(3L, "3-ONE."))
+        accumulator.accumulate(thinkingContentBlockStartEvent(1L, "1-ONE."))
+
+        accumulator.accumulate(textContentBlockDeltaEvent(3L, "3-TWO."))
+        accumulator.accumulate(thinkingContentBlockDeltaEvent(1L, "1-TWO."))
+
+        accumulator.accumulate(citationContentBlockDeltaEvent(3L, 234L))
+        accumulator.accumulate(textContentBlockDeltaEvent(3L, "3-THREE."))
+
+        accumulator.accumulate(signatureContentBlockDeltaEvent(1L))
+
+        accumulator.accumulate(contentBlockStopEvent(3L))
+        accumulator.accumulate(contentBlockStopEvent(1L))
+
+        accumulator.accumulate(
+            messageDeltaEvent(stopReason = JsonField.of(StopReason.END_TURN), outputTokens = 88L)
+        )
+        accumulator.accumulate(messageStopEvent())
+
+        val message = accumulator.message()
+        val content = message.content()
+
+        assertThat(message.stopSequence().getOrNull()).isNull()
+        assertThat(message.stopReason().get()).isEqualTo(Message.StopReason.END_TURN)
+        assertThat(message.usage().inputTokens()).isEqualTo(INPUT_TOKENS)
+        assertThat(message.usage().outputTokens()).isEqualTo(88L)
+
+        assertThat(content.size).isEqualTo(2)
+        assertThat(content[0].asThinking().thinking()).isEqualTo("1-ONE.1-TWO.")
+        assertThat(content[0].asThinking().signature()).isEqualTo("a-signature")
+
+        assertThat(content[1].asText().text()).isEqualTo("3-ONE.3-TWO.3-THREE.")
+        assertThat(content[1].asText().citations().get()).isEqualTo(listOf(textCitation(234L)))
+    }
+
+    @Test
+    fun accumulateRedactedThinkingAndTextContentBlocks() {
+        val accumulator = MessageAccumulator()
+
+        accumulator.accumulate(messageStartEvent())
+
+        accumulator.accumulate(textContentBlockStartEvent(3L, "3-ONE."))
+        accumulator.accumulate(redactedThinkingContentBlockStartEvent(1L, "1-ONE."))
+
+        // `redacting_thinking` content blocks never have any delta events.
+        accumulator.accumulate(textContentBlockDeltaEvent(3L, "3-TWO."))
+
+        accumulator.accumulate(citationContentBlockDeltaEvent(3L, 234L))
+        accumulator.accumulate(textContentBlockDeltaEvent(3L, "3-THREE."))
+
+        accumulator.accumulate(contentBlockStopEvent(3L))
+        accumulator.accumulate(contentBlockStopEvent(1L))
+
+        accumulator.accumulate(
+            messageDeltaEvent(stopReason = JsonField.of(StopReason.END_TURN), outputTokens = 88L)
+        )
+        accumulator.accumulate(messageStopEvent())
+
+        val message = accumulator.message()
+        val content = message.content()
+
+        assertThat(message.stopSequence().getOrNull()).isNull()
+        assertThat(message.stopReason().get()).isEqualTo(Message.StopReason.END_TURN)
+        assertThat(message.usage().inputTokens()).isEqualTo(INPUT_TOKENS)
+        assertThat(message.usage().outputTokens()).isEqualTo(88L)
+
+        assertThat(content.size).isEqualTo(2)
+        assertThat(content[0].asRedactedThinking().data()).isEqualTo("1-ONE.")
+
+        assertThat(content[1].asText().text()).isEqualTo("3-ONE.3-TWO.3-THREE.")
+        assertThat(content[1].asText().citations().get()).isEqualTo(listOf(textCitation(234L)))
+    }
+
+    @Test
+    fun fixtureCreation() {
+        // A quick smoke test to ensure that all the test fixture factory functions work without
+        // throwing any exceptions unless expected to do so.
+
+        // MESSAGE EVENTS
+        assertThatNoException().isThrownBy { messageStartEvent() }
+
+        assertThatNoException().isThrownBy {
+            messageDeltaEvent(stopReason = JsonField.of(StopReason.END_TURN))
+        }
+        assertThatNoException().isThrownBy { messageDeltaEvent(outputTokens = 99) }
+        assertThatNoException().isThrownBy {
+            messageDeltaEvent(JsonField.of(StopReason.STOP_SEQUENCE), JsonField.of("stop sequence"))
+        }
+        // Expect no enforcement of requiring `stop_sequence` if `stop_reason` is `"stop_sequence"`.
+        assertThatNoException().isThrownBy {
+            messageDeltaEvent(JsonField.of(StopReason.STOP_SEQUENCE), stopSequence = SET_TO_NULL)
+        }
+        // Expect no enforcement of requiring `stop_reason` is `"stop_sequence"` when
+        // `stop_sequence` is set.
+        assertThatNoException().isThrownBy {
+            messageDeltaEvent(stopReason = SET_TO_NULL, JsonField.of("stop sequence"))
+        }
+        assertThatNoException().isThrownBy {
+            messageDeltaEvent(JsonField.of(StopReason.END_TURN), JsonField.of("stop sequence"))
+        }
+
+        assertThatNoException().isThrownBy { messageStopEvent() }
+
+        // TEXT CONTENT BLOCK EVENTS (INCLUDING CITATIONS)
+        assertThatNoException().isThrownBy { textContentBlockStartEvent(1L, "text") }
+        assertThatNoException().isThrownBy { textContentBlockStartEvent(1L, "text", 101L) }
+        assertThatNoException().isThrownBy { textContentBlockDeltaEvent(1L, "more text") }
+        assertThatNoException().isThrownBy { citationContentBlockDeltaEvent(1L, 102L) }
+
+        // TOOL USE CONTENT BLOCK EVENTS
+        assertThatNoException().isThrownBy { toolUseContentBlockStartEvent(1L) }
+        assertThatNoException().isThrownBy { toolUseContentBlockDeltaEvent(1L, "{") }
+
+        // THINKING CONTENT BLOCK EVENTS (INCLUDING SIGNATURES)
+        assertThatNoException().isThrownBy { thinkingContentBlockStartEvent(1L) }
+        assertThatNoException().isThrownBy { thinkingContentBlockDeltaEvent(1L, "[thought-2]") }
+        assertThatNoException().isThrownBy { signatureContentBlockDeltaEvent(1L) }
+
+        // REDACTED THINKING CONTENT BLOCK EVENTS
+        assertThatNoException().isThrownBy { redactedThinkingContentBlockStartEvent(1L, null) }
+        assertThatNoException().isThrownBy { redactedThinkingContentBlockStartEvent(1L, "data") }
+
+        // COMMON CONTENT BLOCK STOP EVENT
+        assertThatNoException().isThrownBy { contentBlockStopEvent(1L) }
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // In all the following test fixture factory functions, the `type` property (where relevant) is
+    // not set explicitly, as it always has an appropriate non-null default value.
+
+    private fun messageStartEvent(): RawMessageStreamEvent =
+        RawMessageStreamEvent.ofStart(
+            RawMessageStartEvent.builder()
+                .message(
+                    Message.builder()
+                        .id("message-id")
+                        .model(Model.CLAUDE_3_5_SONNET_LATEST)
+                        .content(listOf())
+                        .usage(usage(INPUT_TOKENS))
+                        // `stopReason()` and `stopSequence()` must be set explicitly or an error
+                        // will occur, but there is no appropriate value other than an explicit "not
+                        // set" for a `message_start` event. The final values will be notified in
+                        // one or more later `message_delta` events.
+                        .stopReason(NOT_SET)
+                        .stopSequence(NOT_SET)
+                        // The default non-null value for `role` suffices.
+                        .build()
+                )
+                .build()
+        )
+
+    /**
+     * Creates a `message_delta` event that can set the `stop_reason` and the `stop_sequence`, and
+     * increment the count of `output_tokens`.
+     *
+     * When all `message_delta` events have been accumulated, the `stop_reason` should be set to a
+     * non-`null` value to emulate what happens in real-world scenarios. The `stop_sequence` should
+     * be set to a non-`null` value if the `stop_reason` is `"stop_sequence"`. None of these
+     * expectations are enforced either here or in the Message API.
+     *
+     * @param stopReason The default value is `NOT_SET` (`JsonMissing`), which is interpreted as the
+     *   field not being set, not even to `null`; when the event is accumulated with the message,
+     *   any existing value of the stop reason will remain unchanged. Use `SET_TO_NULL` to
+     *   explicitly set the field to have a `null` (really `JsonNull`) value, when the event is
+     *   accumulated with the message, any existing value of the stop reason will be overwritten
+     *   with `null`. Otherwise, set the value to the required stop reason; when the event is
+     *   accumulated with the message, any existing value of the stop reason will be replaced with
+     *   the new value.
+     * @param stopSequence The behavior follows the pattern of [stopReason].
+     * @param outputTokens The number of output tokens to _add_ to the current count of output
+     *   tokens already accumulated by the message.
+     */
+    private fun messageDeltaEvent(
+        stopReason: JsonField<StopReason> = NOT_SET,
+        stopSequence: JsonField<String> = NOT_SET,
+        outputTokens: Long = 0L,
+    ): RawMessageStreamEvent =
+        RawMessageStreamEvent.ofDelta(
+            RawMessageDeltaEvent.builder()
+                .delta(
+                    RawMessageDeltaEvent.Delta.builder()
+                        .stopReason(stopReason)
+                        .stopSequence(stopSequence)
+                        .build()
+                )
+                .usage(MessageDeltaUsage.builder().outputTokens(outputTokens).build())
+                .build()
+        )
+
+    private fun messageStopEvent(): RawMessageStreamEvent =
+        RawMessageStreamEvent.ofStop(RawMessageStopEvent.builder().build())
+
+    /**
+     * @param citationPageNumber Omit (or use `null`) to create a text content block without any
+     *   citations.
+     */
+    private fun textContentBlockStartEvent(
+        index: Long,
+        text: String,
+        citationPageNumber: Long? = null,
+    ): RawMessageStreamEvent =
+        contentBlockStartEvent(
+            index,
+            ContentBlock.ofText(
+                TextBlock.builder()
+                    .text(text)
+                    .apply {
+                        // `citations` cannot remain `null` when `build()` is called, so set the "no
+                        // citations" state explicitly with an empty list if needed.
+                        citationPageNumber?.let {
+                            addCitation(
+                                TextCitation.ofCitationPageLocation(
+                                    citationPageLocation(citationPageNumber)
+                                )
+                            )
+                        } ?: citations(listOf())
+                    }
+                    .build()
+            ),
+        )
+
+    private fun textContentBlockDeltaEvent(index: Long, text: String): RawMessageStreamEvent =
+        contentBlockDeltaEvent(index, textDelta(text))
+
+    /**
+     * Creates a citation content block delta event. This can be used to add a citation to a text
+     * content block and should be used between [textContentBlockStartEvent] and its corresponding
+     * [contentBlockStopEvent].
+     */
+    private fun citationContentBlockDeltaEvent(
+        index: Long,
+        pageNumber: Long,
+    ): RawMessageStreamEvent = contentBlockDeltaEvent(index, citationsDelta(pageNumber))
+
+    private fun toolUseContentBlockStartEvent(
+        index: Long,
+        name: String = "tool-name",
+    ): RawMessageStreamEvent =
+        contentBlockStartEvent(
+            index,
+            ContentBlock.ofToolUse(
+                ToolUseBlock.builder().id("tool-id").name(name).input(SET_TO_NULL).build()
+            ),
+        )
+
+    private fun toolUseContentBlockDeltaEvent(
+        index: Long,
+        partialJson: String,
+    ): RawMessageStreamEvent =
+        contentBlockDeltaEvent(index, InputJsonDelta.builder().partialJson(partialJson).build())
+
+    private fun thinkingContentBlockStartEvent(index: Long, thinking: String = "[thought-1"): RawMessageStreamEvent =
+        contentBlockStartEvent(
+            index,
+            ContentBlock.ofThinking(
+                ThinkingBlock.builder()
+                    .thinking(thinking)
+                    // No signature is set for the `content_block_start` event. A single
+                    // `content_block_delta` event, just before the `content_block_stop` event will
+                    // provide the final signature.
+                    .signature(SET_TO_NULL)
+                    .build()
+            ),
+        )
+
+    private fun thinkingContentBlockDeltaEvent(
+        index: Long,
+        thinking: String,
+    ): RawMessageStreamEvent = contentBlockDeltaEvent(index, thinkingDelta(thinking))
+
+    /**
+     * Creates a `redacted_thinking` content block start event. This type of content block will
+     * never have any associated content block delta events.
+     */
+    private fun redactedThinkingContentBlockStartEvent(
+        index: Long,
+        data: String?,
+    ): RawMessageStreamEvent =
+        contentBlockStartEvent(
+            index,
+            ContentBlock.ofRedactedThinking(
+                RedactedThinkingBlock.builder().data(JsonField.ofNullable(data)).build()
+            ),
+        )
+
+    /**
+     * Creates a signature content block delta event. This can be used to add a signature to a
+     * `tool_use` content block and should be used between [toolUseContentBlockStartEvent] and its
+     * corresponding [contentBlockStopEvent].
+     */
+    private fun signatureContentBlockDeltaEvent(index: Long): RawMessageStreamEvent =
+        contentBlockDeltaEvent(index, signatureDelta("a-signature"))
+
+    private fun contentBlockStartEvent(
+        index: Long,
+        contentBlock: ContentBlock,
+    ): RawMessageStreamEvent =
+        RawMessageStreamEvent.ofContentBlockStart(
+            RawContentBlockStartEvent.builder().index(index).contentBlock(contentBlock).build()
+        )
+
+    private fun contentBlockDeltaEvent(index: Long, delta: Any): RawMessageStreamEvent =
+        RawMessageStreamEvent.ofContentBlockDelta(
+            RawContentBlockDeltaEvent.builder()
+                .index(index)
+                .apply {
+                    when (delta) {
+                        is TextDelta -> delta(delta)
+                        is CitationsDelta -> delta(delta)
+                        is InputJsonDelta -> delta(delta)
+                        is ThinkingDelta -> delta(delta)
+                        is SignatureDelta -> delta(delta)
+                        // There are no delta events for `redacted_thinking` content blocks.
+                        else ->
+                            throw IllegalArgumentException(
+                                "Unknown delta type ${delta::class.java}"
+                            )
+                    }
+                }
+                .build()
+        )
+
+    // One type of `content_block_stop` event that is common to all types of content blocks.
+    private fun contentBlockStopEvent(index: Long): RawMessageStreamEvent =
+        RawMessageStreamEvent.ofContentBlockStop(
+            RawContentBlockStopEvent.builder().index(index).build()
+        )
+
+    private fun usage(inputTokens: Long): Usage =
+        Usage.builder()
+            .inputTokens(inputTokens)
+            .cacheCreationInputTokens(0L)
+            .cacheReadInputTokens(0L)
+            .outputTokens(0L)
+            .build()
+
+    private fun textDelta(text: String): TextDelta = TextDelta.builder().text(text).build()
+
+    private fun citationsDelta(pageNumber: Long): CitationsDelta =
+        CitationsDelta.builder().citation(citationPageLocation(pageNumber)).build()
+
+    private fun citationPageLocation(pageNumber: Long): CitationPageLocation =
+        CitationPageLocation.builder()
+            .documentTitle("Document Title")
+            .documentIndex(11L)
+            .citedText("cited text")
+            .startPageNumber(pageNumber)
+            .endPageNumber(pageNumber)
+            .build()
+
+    private fun citationContentBlockLocation(blockIndex: Long): CitationContentBlockLocation =
+        CitationContentBlockLocation.builder()
+            .documentTitle("Document Title")
+            .documentIndex(11L)
+            .citedText("cited text")
+            .startBlockIndex(blockIndex)
+            .endBlockIndex(blockIndex)
+            .build()
+
+    private fun citationCharLocation(charIndex: Long): CitationCharLocation =
+        CitationCharLocation.builder()
+            .documentTitle("Document Title")
+            .documentIndex(11L)
+            .citedText("cited text")
+            .startCharIndex(charIndex)
+            .endCharIndex(charIndex)
+            .build()
+
+    private fun textCitation(pageNumber: Long): TextCitation =
+        TextCitation.ofCitationPageLocation(citationPageLocation(pageNumber))
+
+    private fun thinkingDelta(thinking: String): ThinkingDelta =
+        ThinkingDelta.builder().thinking(thinking).build()
+
+    private fun signatureDelta(signature: String): SignatureDelta =
+        SignatureDelta.builder().signature(signature).build()
+
+    private fun textBlock(text: String): TextBlock =
+        TextBlock.builder().text(text).citations(listOf()).build()
+
+    private fun thinkingBlock(
+        thinking: String = "[thinking]",
+        signature: String = "[signature]",
+    ): ThinkingBlock = ThinkingBlock.builder().thinking(thinking).signature(signature).build()
+}


### PR DESCRIPTION
Draft of a new `MessageAccumulator` that accumulates events from an SSE stream and builds up a `Message` object.

Some outstanding decisions/questions are marked with `// TODO: ...` comments.