### PR TITLE
Add support for Bedrock access using AWS_BEARER_TOKEN_BEDROCK #265

### DIFF
--- a/README.md
+++ b/README.md
@@ -668,24 +668,44 @@ To use Anthropic on Bedrock, create the Anthropic client with the
 [`BedrockBackend`](anthropic-java-bedrock/src/main/kotlin/com/anthropic/bedrock/backends/BedrockBackend.kt).
 Usage of the API is otherwise the same.
 
+Amazon Bedrock supports two authentication methods:
+
+#### Bearer Token Authentication (Recommended for Development)
+
+Amazon Bedrock API keys provide a simpler authentication method for development and experimentation. Set the `AWS_BEARER_TOKEN_BEDROCK` environment variable with your API key:
+
 ```java
 import com.anthropic.bedrock.backends.BedrockBackend;
 import com.anthropic.client.AnthropicClient;
 import com.anthropic.client.okhttp.AnthropicOkHttpClient;
 
+// Automatically uses AWS_BEARER_TOKEN_BEDROCK if available
 AnthropicClient client = AnthropicOkHttpClient.builder()
         .backend(BedrockBackend.fromEnv())
         .build();
 ```
 
+Or set the Bearer token explicitly:
+
+```java
+AnthropicClient client = AnthropicOkHttpClient.builder()
+        .backend(BedrockBackend.builder()
+                .bearerToken("your-bedrock-api-key")
+                .region(Region.US_EAST_1)
+                .build())
+        .build();
+```
+
+#### AWS SigV4 Authentication (Recommended for Production)
+
 `BedrockBackend.fromEnv()` automatically resolves the AWS credentials using the
 [AWS default credentials provider chain](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials-chain.html)
 and resolves the AWS region using the
-[AWS default region provider chain](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/region-selection.html).
-See those AWS documents for details on how to configure the AWS credentials and
+[AWS default region provider chain](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/region-selection.html)
+when no Bearer token is present. See those AWS documents for details on how to configure the AWS credentials and
 AWS region for resolution by those provider chains.
 
-Instead of resolving the AWS credentials and AWS region using the default AWS
+For SigV4 authentication, instead of resolving the AWS credentials and AWS region using the default AWS
 provider chains, you can resolve them independently using any provider, or any
 scheme of your choice, and pass them directly to the `BedrockBackend` during
 building. For example, you can resolve the AWS credentials directly from

--- a/README.md
+++ b/README.md
@@ -678,23 +678,6 @@ AnthropicClient client = AnthropicOkHttpClient.builder()
         .build();
 ```
 
-#### Authentication Methods
-
-Amazon Bedrock supports two authentication methods, both handled automatically by the AWS SDK:
-
-**API Key Authentication (Recommended for Development)**
-
-The simplest way to get started is using Amazon Bedrock API keys. Set the `AWS_BEARER_TOKEN_BEDROCK` environment variable:
-
-```bash
-export AWS_BEARER_TOKEN_BEDROCK=your-api-key-here
-export AWS_REGION=us-east-1
-```
-
-> **Note:** Long-term API keys are recommended only for exploration and development. For production applications, use alternatives to long-term access keys such as IAM roles or temporary credentials.
-
-**AWS Credentials Authentication**
-
 `BedrockBackend.fromEnv()` automatically resolves the AWS credentials using the
 [AWS default credentials provider chain](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials-chain.html)
 and resolves the AWS region using the
@@ -702,7 +685,8 @@ and resolves the AWS region using the
 See those AWS documents for details on how to configure the AWS credentials and
 AWS region for resolution by those provider chains.
 
-Instead of using the default AWS provider chains, you can resolve the AWS credentials and AWS region independently using any provider, or any
+Instead of resolving the AWS credentials and AWS region using the default AWS
+provider chains, you can resolve them independently using any provider, or any
 scheme of your choice, and pass them directly to the `BedrockBackend` during
 building. For example, you can resolve the AWS credentials directly from
 environment variables and hard-code the AWS region:

--- a/README.md
+++ b/README.md
@@ -678,6 +678,23 @@ AnthropicClient client = AnthropicOkHttpClient.builder()
         .build();
 ```
 
+#### Authentication Methods
+
+Amazon Bedrock supports two authentication methods, both handled automatically by the AWS SDK:
+
+**API Key Authentication (Recommended for Development)**
+
+The simplest way to get started is using Amazon Bedrock API keys. Set the `AWS_BEARER_TOKEN_BEDROCK` environment variable:
+
+```bash
+export AWS_BEARER_TOKEN_BEDROCK=your-api-key-here
+export AWS_REGION=us-east-1
+```
+
+> **Note:** Long-term API keys are recommended only for exploration and development. For production applications, use alternatives to long-term access keys such as IAM roles or temporary credentials.
+
+**AWS Credentials Authentication**
+
 `BedrockBackend.fromEnv()` automatically resolves the AWS credentials using the
 [AWS default credentials provider chain](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials-chain.html)
 and resolves the AWS region using the
@@ -685,8 +702,7 @@ and resolves the AWS region using the
 See those AWS documents for details on how to configure the AWS credentials and
 AWS region for resolution by those provider chains.
 
-Instead of resolving the AWS credentials and AWS region using the default AWS
-provider chains, you can resolve them independently using any provider, or any
+Instead of using the default AWS provider chains, you can resolve the AWS credentials and AWS region independently using any provider, or any
 scheme of your choice, and pass them directly to the `BedrockBackend` during
 building. For example, you can resolve the AWS credentials directly from
 environment variables and hard-code the AWS region:

--- a/anthropic-java-bedrock/build.gradle.kts
+++ b/anthropic-java-bedrock/build.gradle.kts
@@ -14,7 +14,7 @@ dependencies {
     // use in code (where necessary) that depends on this Anthropic SDK library
     // module. The BOM must be declared as an "api" dependency if any of its
     // modules are declared as "api" dependencies.
-    api(platform("software.amazon.awssdk:bom:2.30.11"))
+    api(platform("software.amazon.awssdk:bom:2.31.74"))
     api("software.amazon.awssdk:auth")
     implementation("software.amazon.awssdk:http-client-spi")
 

--- a/anthropic-java-bedrock/build.gradle.kts
+++ b/anthropic-java-bedrock/build.gradle.kts
@@ -14,7 +14,7 @@ dependencies {
     // use in code (where necessary) that depends on this Anthropic SDK library
     // module. The BOM must be declared as an "api" dependency if any of its
     // modules are declared as "api" dependencies.
-    api(platform("software.amazon.awssdk:bom:2.31.74"))
+    api(platform("software.amazon.awssdk:bom:2.30.11"))
     api("software.amazon.awssdk:auth")
     implementation("software.amazon.awssdk:http-client-spi")
 

--- a/anthropic-java-bedrock/src/main/kotlin/com/anthropic/bedrock/backends/BedrockBackend.kt
+++ b/anthropic-java-bedrock/src/main/kotlin/com/anthropic/bedrock/backends/BedrockBackend.kt
@@ -45,11 +45,6 @@ import software.amazon.eventstream.MessageDecoder
  * passed to [Builder.awsCredentials] and [Builder.region] should an alternative method of
  * resolution be required.
  *
- * As of AWS SDK 2.31.74+, the default credentials provider chain also supports Amazon Bedrock API
- * keys via the AWS_BEARER_TOKEN_BEDROCK environment variable. When this environment variable is
- * set, the AWS SDK will automatically use bearer token authentication instead of traditional AWS
- * credentials for calling Amazon Bedrock API.
- *
  * See the Amazon Bedrock and AWS documentation for details on how to configure AWS credentials.
  */
 class BedrockBackend

--- a/anthropic-java-bedrock/src/main/kotlin/com/anthropic/bedrock/backends/BedrockBackend.kt
+++ b/anthropic-java-bedrock/src/main/kotlin/com/anthropic/bedrock/backends/BedrockBackend.kt
@@ -45,6 +45,11 @@ import software.amazon.eventstream.MessageDecoder
  * passed to [Builder.awsCredentials] and [Builder.region] should an alternative method of
  * resolution be required.
  *
+ * As of AWS SDK 2.31.74+, the default credentials provider chain also supports Amazon Bedrock API
+ * keys via the AWS_BEARER_TOKEN_BEDROCK environment variable. When this environment variable is
+ * set, the AWS SDK will automatically use bearer token authentication instead of traditional AWS
+ * credentials for calling Amazon Bedrock API.
+ *
  * See the Amazon Bedrock and AWS documentation for details on how to configure AWS credentials.
  */
 class BedrockBackend

--- a/anthropic-java-example/src/main/java/com/anthropic/example/BedrockBearerTokenExample.java
+++ b/anthropic-java-example/src/main/java/com/anthropic/example/BedrockBearerTokenExample.java
@@ -1,0 +1,78 @@
+package com.anthropic.example;
+
+import com.anthropic.bedrock.backends.BedrockBackend;
+import com.anthropic.client.AnthropicClient;
+import com.anthropic.client.okhttp.AnthropicOkHttpClient;
+import com.anthropic.models.messages.MessageCreateParams;
+import software.amazon.awssdk.regions.Region;
+
+/**
+ * <p>
+ * An example of retrieving messages from an Anthropic model running on the
+ * Amazon Bedrock backend using Bearer token authentication (Amazon Bedrock API keys).
+ * </p>
+ * <p>
+ * This example demonstrates the new Bearer token authentication method introduced
+ * in AWS SDK Java v2.31.74, which provides a simpler alternative to AWS SigV4
+ * signing for Amazon Bedrock API access.
+ * </p>
+ * <p>
+ * To use Bearer token authentication, you need to generate an Amazon Bedrock API key
+ * from the AWS console and set it as an environment variable or pass it explicitly
+ * to the BedrockBackend builder.
+ * </p>
+ * <p>
+ * To run this example, set the following environment variables:
+ * </p>
+ * <ul>
+ *   <li>{@code AWS_BEARER_TOKEN_BEDROCK}:
+ *       The Amazon Bedrock API key for Bearer token authentication.</li>
+ *   <li>{@code AWS_REGION} (optional):
+ *       The AWS region. If not set, defaults to us-east-1 in this example.</li>
+ * </ul>
+ * <p>
+ * Alternatively, you can set the Bearer token explicitly using the
+ * {@code bearerToken()} method on the BedrockBackend builder.
+ * </p>
+ */
+public final class BedrockBearerTokenExample {
+    private BedrockBearerTokenExample() {}
+
+    public static void main(String[] args) {
+        // Option 1: Use Bearer token from environment variable (AWS_BEARER_TOKEN_BEDROCK)
+        // The fromEnv() method will automatically detect and use the Bearer token if available
+        AnthropicClient clientFromEnv = AnthropicOkHttpClient.builder()
+                .backend(BedrockBackend.fromEnv())
+                .build();
+        System.out.println("BedrockBackend.fromEnv() invoked which uses AWS_BEARER_TOKEN_BEDROCK first, if not found uses default AWS credentials.");
+        invokeClaude(clientFromEnv);
+
+        // Option 2: Set Bearer token explicitly
+        String bearerToken = System.getenv("AWS_BEARER_TOKEN_BEDROCK");
+        if (bearerToken != null) {
+            AnthropicClient clientExplicit = AnthropicOkHttpClient.builder()
+                    .backend(BedrockBackend.builder()
+                            .bearerToken(bearerToken)
+                            .region(Region.US_EAST_1)
+                            .build())
+                    .build();
+            System.out.println("BedrockBackend.builder().bearerToken(bearerToken) invoked which uses AWS_BEARER_TOKEN_BEDROCK explicitly, if not found uses default AWS credentials.");
+            invokeClaude(clientExplicit);
+        }
+
+
+    }
+
+    private static void invokeClaude(AnthropicClient clientFromEnv) {
+        // Use the client (using the fromEnv() version for this example)
+        MessageCreateParams createParams = MessageCreateParams.builder()
+                .model("us.anthropic.claude-sonnet-4-20250514-v1:0")
+                .maxTokens(2048)
+                .addUserMessage("Hello! Can you explain the benefits of using Amazon Bedrock API keys?")
+                .build();
+
+        clientFromEnv.messages().create(createParams).content().stream()
+                .flatMap(contentBlock -> contentBlock.text().stream())
+                .forEach(textBlock -> System.out.println(textBlock.text()));
+    }
+}


### PR DESCRIPTION
Added support for AWS Bearer Token authentication in Bedrock backend

- Update AWS SDK version from 2.30.11 to 2.31.74 to support API key authentication
- Add Bearer token authentication alongside existing SigV4 authentication
- Support AWS_BEARER_TOKEN_BEDROCK environment variable detection
- Add bearerToken() method to BedrockBackend.Builder for explicit configuration
- Bearer token takes precedence over AWS credentials when both are available
- Maintain full backward compatibility with existing AWS credential-based auth
- Add comprehensive test coverage for Bearer token functionality
- Update README.md with Bearer token authentication documentation
- Add BedrockBearerTokenExample.java demonstrating new authentication method

Resolves #265
With a generous help from Amazon Kiro using Claude 4. 