### PR TITLE
fix: add backward-compat shims for renamed nested types

### DIFF
--- a/anthropic-java-core/src/main/kotlin/com/anthropic/models/beta/messages/BetaWebSearchTool20250305.kt
+++ b/anthropic-java-core/src/main/kotlin/com/anthropic/models/beta/messages/BetaWebSearchTool20250305.kt
@@ -763,4 +763,17 @@ private constructor(
 
     override fun toString() =
         "BetaWebSearchTool20250305{name=$name, type=$type, allowedCallers=$allowedCallers, allowedDomains=$allowedDomains, blockedDomains=$blockedDomains, cacheControl=$cacheControl, deferLoading=$deferLoading, maxUses=$maxUses, strict=$strict, userLocation=$userLocation, additionalProperties=$additionalProperties}"
+
+    /**
+     * @deprecated Use [BetaUserLocation] directly instead.
+     */
+    @Deprecated(
+        "Use BetaUserLocation directly instead",
+        ReplaceWith("BetaUserLocation"),
+    )
+    object UserLocation {
+
+        /** Returns a mutable builder for constructing an instance of [BetaUserLocation]. */
+        @JvmStatic fun builder() = BetaUserLocation.builder()
+    }
 }

--- a/anthropic-java-core/src/main/kotlin/com/anthropic/models/beta/messages/BetaWebSearchToolRequestError.kt
+++ b/anthropic-java-core/src/main/kotlin/com/anthropic/models/beta/messages/BetaWebSearchToolRequestError.kt
@@ -216,4 +216,30 @@ private constructor(
 
     override fun toString() =
         "BetaWebSearchToolRequestError{errorCode=$errorCode, type=$type, additionalProperties=$additionalProperties}"
+
+    /**
+     * @deprecated Use [BetaWebSearchToolResultErrorCode] directly instead.
+     */
+    @Deprecated(
+        "Use BetaWebSearchToolResultErrorCode directly instead",
+        ReplaceWith("BetaWebSearchToolResultErrorCode"),
+    )
+    object ErrorCode {
+
+        @JvmField val INVALID_TOOL_INPUT = BetaWebSearchToolResultErrorCode.INVALID_TOOL_INPUT
+
+        @JvmField val UNAVAILABLE = BetaWebSearchToolResultErrorCode.UNAVAILABLE
+
+        @JvmField val MAX_USES_EXCEEDED = BetaWebSearchToolResultErrorCode.MAX_USES_EXCEEDED
+
+        @JvmField val TOO_MANY_REQUESTS = BetaWebSearchToolResultErrorCode.TOO_MANY_REQUESTS
+
+        @JvmField val QUERY_TOO_LONG = BetaWebSearchToolResultErrorCode.QUERY_TOO_LONG
+
+        @JvmField val REQUEST_TOO_LARGE = BetaWebSearchToolResultErrorCode.REQUEST_TOO_LARGE
+
+        @JvmStatic
+        fun of(value: String): BetaWebSearchToolResultErrorCode =
+            BetaWebSearchToolResultErrorCode.of(value)
+    }
 }

--- a/anthropic-java-core/src/main/kotlin/com/anthropic/models/beta/messages/BetaWebSearchToolResultError.kt
+++ b/anthropic-java-core/src/main/kotlin/com/anthropic/models/beta/messages/BetaWebSearchToolResultError.kt
@@ -215,4 +215,30 @@ private constructor(
 
     override fun toString() =
         "BetaWebSearchToolResultError{errorCode=$errorCode, type=$type, additionalProperties=$additionalProperties}"
+
+    /**
+     * @deprecated Use [BetaWebSearchToolResultErrorCode] directly instead.
+     */
+    @Deprecated(
+        "Use BetaWebSearchToolResultErrorCode directly instead",
+        ReplaceWith("BetaWebSearchToolResultErrorCode"),
+    )
+    object ErrorCode {
+
+        @JvmField val INVALID_TOOL_INPUT = BetaWebSearchToolResultErrorCode.INVALID_TOOL_INPUT
+
+        @JvmField val UNAVAILABLE = BetaWebSearchToolResultErrorCode.UNAVAILABLE
+
+        @JvmField val MAX_USES_EXCEEDED = BetaWebSearchToolResultErrorCode.MAX_USES_EXCEEDED
+
+        @JvmField val TOO_MANY_REQUESTS = BetaWebSearchToolResultErrorCode.TOO_MANY_REQUESTS
+
+        @JvmField val QUERY_TOO_LONG = BetaWebSearchToolResultErrorCode.QUERY_TOO_LONG
+
+        @JvmField val REQUEST_TOO_LARGE = BetaWebSearchToolResultErrorCode.REQUEST_TOO_LARGE
+
+        @JvmStatic
+        fun of(value: String): BetaWebSearchToolResultErrorCode =
+            BetaWebSearchToolResultErrorCode.of(value)
+    }
 }

--- a/anthropic-java-core/src/main/kotlin/com/anthropic/models/messages/WebSearchTool20250305.kt
+++ b/anthropic-java-core/src/main/kotlin/com/anthropic/models/messages/WebSearchTool20250305.kt
@@ -31,7 +31,7 @@ private constructor(
     private val deferLoading: JsonField<Boolean>,
     private val maxUses: JsonField<Long>,
     private val strict: JsonField<Boolean>,
-    private val userLocation: JsonField<UserLocation>,
+    private val userLocation: JsonField<com.anthropic.models.messages.UserLocation>,
     private val additionalProperties: MutableMap<String, JsonValue>,
 ) {
 
@@ -58,7 +58,7 @@ private constructor(
         @JsonProperty("strict") @ExcludeMissing strict: JsonField<Boolean> = JsonMissing.of(),
         @JsonProperty("user_location")
         @ExcludeMissing
-        userLocation: JsonField<UserLocation> = JsonMissing.of(),
+        userLocation: JsonField<com.anthropic.models.messages.UserLocation> = JsonMissing.of(),
     ) : this(
         name,
         type,
@@ -163,7 +163,7 @@ private constructor(
      * @throws AnthropicInvalidDataException if the JSON field has an unexpected type (e.g. if the
      *   server responded with an unexpected value).
      */
-    fun userLocation(): Optional<UserLocation> = userLocation.getOptional("user_location")
+    fun userLocation(): Optional<com.anthropic.models.messages.UserLocation> = userLocation.getOptional("user_location")
 
     /**
      * Returns the raw JSON value of [allowedCallers].
@@ -231,7 +231,7 @@ private constructor(
      */
     @JsonProperty("user_location")
     @ExcludeMissing
-    fun _userLocation(): JsonField<UserLocation> = userLocation
+    fun _userLocation(): JsonField<com.anthropic.models.messages.UserLocation> = userLocation
 
     @JsonAnySetter
     private fun putAdditionalProperty(key: String, value: JsonValue) {
@@ -263,7 +263,7 @@ private constructor(
         private var deferLoading: JsonField<Boolean> = JsonMissing.of()
         private var maxUses: JsonField<Long> = JsonMissing.of()
         private var strict: JsonField<Boolean> = JsonMissing.of()
-        private var userLocation: JsonField<UserLocation> = JsonMissing.of()
+        private var userLocation: JsonField<com.anthropic.models.messages.UserLocation> = JsonMissing.of()
         private var additionalProperties: MutableMap<String, JsonValue> = mutableMapOf()
 
         @JvmSynthetic
@@ -472,21 +472,21 @@ private constructor(
         fun strict(strict: JsonField<Boolean>) = apply { this.strict = strict }
 
         /** Parameters for the user's location. Used to provide more relevant search results. */
-        fun userLocation(userLocation: UserLocation?) =
+        fun userLocation(userLocation: com.anthropic.models.messages.UserLocation?) =
             userLocation(JsonField.ofNullable(userLocation))
 
         /** Alias for calling [Builder.userLocation] with `userLocation.orElse(null)`. */
-        fun userLocation(userLocation: Optional<UserLocation>) =
+        fun userLocation(userLocation: Optional<com.anthropic.models.messages.UserLocation>) =
             userLocation(userLocation.getOrNull())
 
         /**
          * Sets [Builder.userLocation] to an arbitrary JSON value.
          *
-         * You should usually call [Builder.userLocation] with a well-typed [UserLocation] value
+         * You should usually call [Builder.userLocation] with a well-typed [com.anthropic.models.messages.UserLocation] value
          * instead. This method is primarily for setting the field to an undocumented or not yet
          * supported value.
          */
-        fun userLocation(userLocation: JsonField<UserLocation>) = apply {
+        fun userLocation(userLocation: JsonField<com.anthropic.models.messages.UserLocation>) = apply {
             this.userLocation = userLocation
         }
 
@@ -760,4 +760,21 @@ private constructor(
 
     override fun toString() =
         "WebSearchTool20250305{name=$name, type=$type, allowedCallers=$allowedCallers, allowedDomains=$allowedDomains, blockedDomains=$blockedDomains, cacheControl=$cacheControl, deferLoading=$deferLoading, maxUses=$maxUses, strict=$strict, userLocation=$userLocation, additionalProperties=$additionalProperties}"
+
+    /**
+     * @deprecated Use [com.anthropic.models.messages.UserLocation] directly instead.
+     */
+    @Deprecated(
+        "Use com.anthropic.models.messages.UserLocation directly instead",
+        ReplaceWith("com.anthropic.models.messages.UserLocation"),
+    )
+    object UserLocation {
+
+        /**
+         * Returns a mutable builder for constructing an instance of
+         * [com.anthropic.models.messages.UserLocation].
+         */
+        @JvmStatic
+        fun builder() = com.anthropic.models.messages.UserLocation.builder()
+    }
 }

--- a/anthropic-java-core/src/main/kotlin/com/anthropic/models/messages/WebSearchToolRequestError.kt
+++ b/anthropic-java-core/src/main/kotlin/com/anthropic/models/messages/WebSearchToolRequestError.kt
@@ -214,4 +214,30 @@ private constructor(
 
     override fun toString() =
         "WebSearchToolRequestError{errorCode=$errorCode, type=$type, additionalProperties=$additionalProperties}"
+
+    /**
+     * @deprecated Use [WebSearchToolResultErrorCode] directly instead.
+     */
+    @Deprecated(
+        "Use WebSearchToolResultErrorCode directly instead",
+        ReplaceWith("WebSearchToolResultErrorCode"),
+    )
+    object ErrorCode {
+
+        @JvmField val INVALID_TOOL_INPUT = WebSearchToolResultErrorCode.INVALID_TOOL_INPUT
+
+        @JvmField val UNAVAILABLE = WebSearchToolResultErrorCode.UNAVAILABLE
+
+        @JvmField val MAX_USES_EXCEEDED = WebSearchToolResultErrorCode.MAX_USES_EXCEEDED
+
+        @JvmField val TOO_MANY_REQUESTS = WebSearchToolResultErrorCode.TOO_MANY_REQUESTS
+
+        @JvmField val QUERY_TOO_LONG = WebSearchToolResultErrorCode.QUERY_TOO_LONG
+
+        @JvmField val REQUEST_TOO_LARGE = WebSearchToolResultErrorCode.REQUEST_TOO_LARGE
+
+        @JvmStatic
+        fun of(value: String): WebSearchToolResultErrorCode =
+            WebSearchToolResultErrorCode.of(value)
+    }
 }

--- a/anthropic-java-core/src/main/kotlin/com/anthropic/models/messages/WebSearchToolResultError.kt
+++ b/anthropic-java-core/src/main/kotlin/com/anthropic/models/messages/WebSearchToolResultError.kt
@@ -214,4 +214,30 @@ private constructor(
 
     override fun toString() =
         "WebSearchToolResultError{errorCode=$errorCode, type=$type, additionalProperties=$additionalProperties}"
+
+    /**
+     * @deprecated Use [WebSearchToolResultErrorCode] directly instead.
+     */
+    @Deprecated(
+        "Use WebSearchToolResultErrorCode directly instead",
+        ReplaceWith("WebSearchToolResultErrorCode"),
+    )
+    object ErrorCode {
+
+        @JvmField val INVALID_TOOL_INPUT = WebSearchToolResultErrorCode.INVALID_TOOL_INPUT
+
+        @JvmField val UNAVAILABLE = WebSearchToolResultErrorCode.UNAVAILABLE
+
+        @JvmField val MAX_USES_EXCEEDED = WebSearchToolResultErrorCode.MAX_USES_EXCEEDED
+
+        @JvmField val TOO_MANY_REQUESTS = WebSearchToolResultErrorCode.TOO_MANY_REQUESTS
+
+        @JvmField val QUERY_TOO_LONG = WebSearchToolResultErrorCode.QUERY_TOO_LONG
+
+        @JvmField val REQUEST_TOO_LARGE = WebSearchToolResultErrorCode.REQUEST_TOO_LARGE
+
+        @JvmStatic
+        fun of(value: String): WebSearchToolResultErrorCode =
+            WebSearchToolResultErrorCode.of(value)
+    }
 }


### PR DESCRIPTION
Add deprecated nested object shims to preserve backward compatibility for code referencing the old nested `ErrorCode` and `UserLocation` types that were extracted to top-level classes.

## Changes

### ErrorCode shims (4 files, no shadowing conflicts)
- `WebSearchToolRequestError.ErrorCode` -> delegates to `WebSearchToolResultErrorCode`
- `WebSearchToolResultError.ErrorCode` -> delegates to `WebSearchToolResultErrorCode`
- `BetaWebSearchToolRequestError.ErrorCode` -> delegates to `BetaWebSearchToolResultErrorCode`
- `BetaWebSearchToolResultError.ErrorCode` -> delegates to `BetaWebSearchToolResultErrorCode`

### UserLocation shims (2 files)
- `BetaWebSearchTool20250305.UserLocation` -> delegates to `BetaUserLocation` (no shadowing)
- `WebSearchTool20250305.UserLocation` -> delegates to `UserLocation` (existing `UserLocation` references fully qualified to avoid shadowing)

All shims are:
- Annotated with `@Deprecated` with appropriate `ReplaceWith` hints
- Placed at the end of each class body to minimize codegen interference
- Provide `builder()` (for UserLocation) or `@JvmField` constants + `of()` (for ErrorCode) matching the old API surface