### PR TITLE
fix: correct Retry-After date header unit mismatch in retry backoff

### DIFF
--- a/anthropic-java-core/src/main/kotlin/com/anthropic/core/http/RetryingHttpClient.kt
+++ b/anthropic-java-core/src/main/kotlin/com/anthropic/core/http/RetryingHttpClient.kt
@@ -201,7 +201,7 @@ private constructor(
                     ?: headers.values("Retry-After").getOrNull(0)?.let { retryAfter ->
                         retryAfter.toFloatOrNull()?.times(TimeUnit.SECONDS.toNanos(1))
                             ?: try {
-                                ChronoUnit.MILLIS.between(
+                                ChronoUnit.NANOS.between(
                                     OffsetDateTime.now(clock),
                                     OffsetDateTime.parse(
                                         retryAfter,


### PR DESCRIPTION
## Summary

- **Bug**: When `Retry-After` header contains an HTTP-date (e.g., `Wed, 21 Oct 2015 07:28:00 GMT`), the retry backoff duration is ~1,000,000x shorter than the server requested.
- **Root cause**: `ChronoUnit.MILLIS.between()` returns milliseconds, but the result flows into `Duration.ofNanos()`, which interprets it as nanoseconds.
- **Fix**: Change `ChronoUnit.MILLIS` to `ChronoUnit.NANOS` so the date-based path produces nanoseconds consistently with the other two code paths (`Retry-After-Ms` and numeric `Retry-After`).

### Before (bug)
A `Retry-After: Wed, 09 Oct 2024 07:28:05 GMT` header (5 seconds in the future) would compute:
```
ChronoUnit.MILLIS.between(now, retryAfter) = 5000  (milliseconds)
Duration.ofNanos(5000) = 5 microseconds  // Wrong! Should be 5 seconds
```

### After (fix)
```
ChronoUnit.NANOS.between(now, retryAfter) = 5000000000  (nanoseconds)
Duration.ofNanos(5000000000) = 5 seconds  // Correct
```

The other two branches already convert correctly to nanoseconds:
- `Retry-After-Ms`: `toFloat() * TimeUnit.MILLISECONDS.toNanos(1)` → nanoseconds
- `Retry-After` (numeric): `toFloat() * TimeUnit.SECONDS.toNanos(1)` → nanoseconds

## Test plan

- [x] Verified existing `execute_withRetryAfterHeader` test still passes (it uses a no-op sleeper, so it validates the flow but not the duration value)
- [ ] A unit test that asserts the correct duration when parsing an HTTP-date `Retry-After` header would fully validate this fix

## AI Disclosure

This PR was authored by Claude Opus 4.6 (Anthropic), an AI agent operated by Maxwell Calkin ([@MaxwellCalkin](https://github.com/MaxwellCalkin)).