### PR TITLE
fix(client): correct "exactly one" check in JSON schema validator

### DIFF
--- a/anthropic-java-core/src/main/kotlin/com/anthropic/core/JsonSchemaValidator.kt
+++ b/anthropic-java-core/src/main/kotlin/com/anthropic/core/JsonSchemaValidator.kt
@@ -213,8 +213,7 @@ internal class JsonSchemaValidator private constructor() {
         val type = schema.get(TYPE)
         val ref = schema.get(REF)
 
-        val presentCount =
-            listOf(anyOf != null, type != null, ref != null).count { it }
+        val presentCount = listOf(anyOf != null, type != null, ref != null).count { it }
         verify(
             presentCount == 1,
             path,

--- a/anthropic-java-core/src/main/kotlin/com/anthropic/core/JsonSchemaValidator.kt
+++ b/anthropic-java-core/src/main/kotlin/com/anthropic/core/JsonSchemaValidator.kt
@@ -213,8 +213,10 @@ internal class JsonSchemaValidator private constructor() {
         val type = schema.get(TYPE)
         val ref = schema.get(REF)
 
+        val presentCount =
+            listOf(anyOf != null, type != null, ref != null).count { it }
         verify(
-            (anyOf != null).xor(type != null).xor(ref != null),
+            presentCount == 1,
             path,
             { "Expected exactly one of '$TYPE' or '$ANY_OF' or '$REF'." },
         ) {


### PR DESCRIPTION
## Summary

- **Bug**: The JSON schema validator's check for "exactly one of `type`, `anyOf`, or `$ref`" uses chained XOR (`a.xor(b).xor(c)`), which evaluates to `true` when an **odd** number of values are true (1 **or 3**), not when exactly one is true.
- **Impact**: A malformed schema containing all three of `type`, `anyOf`, AND `$ref` would incorrectly pass local validation instead of being rejected with an error.
- **Fix**: Replace the chained XOR with `listOf(...).count { it } == 1` which correctly validates exactly one field is present.

### Truth table showing the bug

| `anyOf` | `type` | `$ref` | Count | `a.xor(b).xor(c)` | Correct |
|---------|--------|--------|-------|--------------------|---------|
| F       | F      | F      | 0     | false              | false   |
| T       | F      | F      | 1     | true               | true    |
| F       | T      | F      | 1     | true               | true    |
| F       | F      | T      | 1     | true               | true    |
| T       | T      | F      | 2     | false              | false   |
| T       | F      | T      | 2     | false              | false   |
| F       | T      | T      | 2     | false              | false   |
| **T**   | **T**  | **T**  | **3** | **true (BUG)**     | **false** |

## Test plan

- [x] Verified existing structured output tests still pass with the fix
- [ ] A test with a schema node containing all three fields (`type`, `anyOf`, and `$ref`) would validate the fix catches this edge case

## AI Disclosure

This PR was authored by Claude Opus 4.6 (Anthropic), an AI agent operated by Maxwell Calkin ([@MaxwellCalkin](https://github.com/MaxwellCalkin)).