### PR TITLE
Adding interceptor support so trace propagation can be plugged

### DIFF
--- a/anthropic-java-client-okhttp/src/main/kotlin/com/anthropic/client/okhttp/OkHttpClient.kt
+++ b/anthropic-java-client-okhttp/src/main/kotlin/com/anthropic/client/okhttp/OkHttpClient.kt
@@ -232,6 +232,7 @@ internal constructor(
         private var sslSocketFactory: SSLSocketFactory? = null
         private var trustManager: X509TrustManager? = null
         private var hostnameVerifier: HostnameVerifier? = null
+        private val interceptors: MutableList<okhttp3.Interceptor> = mutableListOf()
 
         fun timeout(timeout: Timeout) = apply { this.timeout = timeout }
 
@@ -279,6 +280,33 @@ internal constructor(
             this.hostnameVerifier = hostnameVerifier
         }
 
+        /**
+         * Adds a custom OkHttp [okhttp3.Interceptor] that will be applied to every request.
+         *
+         * This is useful for cross-cutting concerns such as trace context propagation. For example,
+         * to forward an `X-Trace-Id` header from an incoming request using a [ThreadLocal]:
+         *
+         * ```kotlin
+         * val traceIdHolder = ThreadLocal<String>()
+         *
+         * val httpClient = OkHttpClient.builder()
+         *     .backend(backend)
+         *     .addInterceptor { chain ->
+         *         val traceId = traceIdHolder.get()
+         *         val request = if (traceId != null) {
+         *             chain.request().newBuilder().addHeader("X-Trace-Id", traceId).build()
+         *         } else {
+         *             chain.request()
+         *         }
+         *         chain.proceed(request)
+         *     }
+         *     .build()
+         * ```
+         */
+        fun addInterceptor(interceptor: okhttp3.Interceptor) = apply {
+            interceptors.add(interceptor)
+        }
+
         fun build(): OkHttpClient =
             OkHttpClient(
                 okhttp3.OkHttpClient.Builder()
@@ -320,6 +348,8 @@ internal constructor(
                         }
 
                         hostnameVerifier?.let(::hostnameVerifier)
+
+                        interceptors.forEach { addInterceptor(it) }
                     }
                     .build()
                     .apply {

--- a/anthropic-java-client-okhttp/src/test/kotlin/com/anthropic/client/okhttp/OkHttpClientTest.kt
+++ b/anthropic-java-client-okhttp/src/test/kotlin/com/anthropic/client/okhttp/OkHttpClientTest.kt
@@ -31,6 +31,43 @@ internal class OkHttpClientTest {
     }
 
     @Test
+    fun addInterceptor_interceptorIsCalledAndCanAddHeaders() {
+        stubFor(post(urlPathEqualTo("/something")).willReturn(ok()))
+        val traceIdHolder = ThreadLocal<String>()
+        val clientWithInterceptor =
+            OkHttpClient.builder()
+                .backend(TestBackend(baseUrl))
+                .addInterceptor { chain ->
+                    val traceId = traceIdHolder.get()
+                    val request =
+                        if (traceId != null) {
+                            chain.request().newBuilder().addHeader("X-Trace-Id", traceId).build()
+                        } else {
+                            chain.request()
+                        }
+                    chain.proceed(request)
+                }
+                .build()
+
+        traceIdHolder.set("test-trace-123")
+        try {
+            clientWithInterceptor
+                .execute(
+                    HttpRequest.builder()
+                        .method(HttpMethod.POST)
+                        .baseUrl(baseUrl)
+                        .addPathSegment("something")
+                        .build()
+                )
+                .close()
+        } finally {
+            traceIdHolder.remove()
+        }
+
+        verify(postRequestedFor(urlPathEqualTo("/something")).withHeader("X-Trace-Id", equalTo("test-trace-123")))
+    }
+
+    @Test
     fun executeAsync_whenFutureCancelled_cancelsUnderlyingCall() {
         stubFor(post(urlPathEqualTo("/something")).willReturn(ok()))
         val responseFuture =


### PR DESCRIPTION
Supporting pluggable OK Http interceptor to for example support trace propagation

For example, to propagate X-Trace-Id from an incoming request                                                                                                      
                                                                                                                                                                
In a Spring Boot / Servlet filter context

```                                                                                                                                                                
  // Shared ThreadLocal — set this from your servlet filter or interceptor                                                                                    
  public static final ThreadLocal<String> TRACE_ID = new ThreadLocal<>();                                                                                       
                                                                                                                                                                
  // Build the client once at startup                                                                                                                           
  OkHttpClient httpClient = OkHttpClient.builder()                                                                                                              
      .backend(backend)                                                                                                                                         
      .addInterceptor(chain -> {
          String traceId = TRACE_ID.get();                                                                                                                      
          okhttp3.Request request = traceId != null                                                                                                           
              ? chain.request().newBuilder().addHeader("X-Trace-Id", traceId).build()
              : chain.request();                                                                                                                                
          return chain.proceed(request);
      })                                                                                                                                                        
      .build();                                                                                                                                               

  AnthropicClient client = AnthropicOkHttpClient.builder()                                                                                                      
      .apiKey("...")
      .httpClient(httpClient)                                                                                                                                   
      .build();                                                                                                                                               

  // In your Spring HandlerInterceptor or servlet Filter:                                                                                                       
  TRACE_ID.set(request.getHeader("X-Trace-Id"));
  try {                                                                                                                                                         
      // handle request — the Anthropic client will forward the header                                                                                          
  } finally {
      TRACE_ID.remove(); // prevent leaks across thread reuse                                                                                                   
  }      
```                                                                                                                                                       
   
  With OpenTelemetry / Brave (if already using a tracing framework)                                                                                             
                                                                                                                                                              
  If you're already using OTel or Brave, you can use their context propagators directly instead of ThreadLocal:                                                 

```                                                                                                                                                              
  .addInterceptor(chain -> {                                                                                                                                    
      // OTel example                                                                                                                                         
      Span span = Span.current();
      String traceId = span.getSpanContext().getTraceId();                                                                                                      
      return chain.proceed(
          chain.request().newBuilder().addHeader("X-Trace-Id", traceId).build()                                                                                 
      );                                                                                                                                                      
  })     
```