### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
           cache: gradle
 
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1 # v4.4.4 (sha-pinned)
 
       - name: Run lints
         run: ./scripts/lint
@@ -61,7 +61,7 @@ jobs:
           cache: gradle
 
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1 # v4.4.4 (sha-pinned)
 
       - name: Build SDK
         run: ./scripts/build
@@ -103,7 +103,7 @@ jobs:
           cache: gradle
 
       - name: Set up Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@a8f75513eafdebd8141bd1cd4e30fcd194af8dfa # v2.12.0 (sha-pinned)
 
       - name: Run tests
         run: ./scripts/test

--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Set up Gradle
         if: ${{ steps.release.outputs.releases_created }}
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@a8f75513eafdebd8141bd1cd4e30fcd194af8dfa # v2.12.0 (sha-pinned)
 
       - name: Publish to Sonatype
         if: ${{ steps.release.outputs.releases_created }}

--- a/.github/workflows/detect-breaking-changes.yml
+++ b/.github/workflows/detect-breaking-changes.yml
@@ -29,7 +29,7 @@ jobs:
             21
           cache: gradle
       - name: Set up Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@a8f75513eafdebd8141bd1cd4e30fcd194af8dfa # v2.12.0 (sha-pinned)
 
       - name: Detect breaking changes
         run: |

--- a/.github/workflows/publish-sonatype.yml
+++ b/.github/workflows/publish-sonatype.yml
@@ -22,7 +22,7 @@ jobs:
           cache: gradle
 
       - name: Set up Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@a8f75513eafdebd8141bd1cd4e30fcd194af8dfa # v2.12.0 (sha-pinned)
 
       - name: Publish to Sonatype
         run: |-


### PR DESCRIPTION
Pin third-party GitHub Actions references to immutable commit SHAs.