### PR TITLE
docs(contributing): point mock-server steps to Steady, not Prism

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,10 +31,10 @@ $ ./gradlew :anthropic-java-example:run
 
 ## Running tests
 
-Most tests require you to [set up a mock server](https://github.com/stoplightio/prism) against the OpenAPI spec to run the tests.
+Most tests require you to [set up a mock server](https://github.com/dgellow/steady) against the OpenAPI spec to run the tests.
 
 ```sh
-$ npx prism mock path/to/your/openapi.yml
+$ ./scripts/mock
 ```
 
 ```sh


### PR DESCRIPTION
## Summary
- Updates `CONTRIBUTING.md` "Running tests" instructions to reference Steady (`./scripts/mock`) rather than Prism (`npx prism mock`).
- Matches what `scripts/mock` and `scripts/test` actually do (they query `/_x-steady/health`).
- Aligns the Java SDK with the equivalent change already in the Ruby SDK's `CONTRIBUTING.md`.

## Verification
- Only a manual file (`CONTRIBUTING.md`) is touched — no `@generated` / Stainless markers
- Markdown code fences remain balanced
- `scripts/mock` exists and is executable; it sources the spec URL from `.stats.yml`
