### PR TITLE
chore: bump Jackson from 2.18.2 to 2.19.2

### DIFF
--- a/anthropic-java-core/build.gradle.kts
+++ b/anthropic-java-core/build.gradle.kts
@@ -24,16 +24,16 @@ configurations.all {
 }
 
 dependencies {
-    api("com.fasterxml.jackson.core:jackson-core:2.18.2")
-    api("com.fasterxml.jackson.core:jackson-databind:2.18.2")
+    api("com.fasterxml.jackson.core:jackson-core:2.19.2")
+    api("com.fasterxml.jackson.core:jackson-databind:2.19.2")
     api("com.google.errorprone:error_prone_annotations:2.33.0")
     api("com.standardwebhooks:standardwebhooks:1.1.0")
     api("io.swagger.core.v3:swagger-annotations:2.2.31")
 
-    implementation("com.fasterxml.jackson.core:jackson-annotations:2.18.2")
-    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.18.2")
-    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.18.2")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.18.2")
+    implementation("com.fasterxml.jackson.core:jackson-annotations:2.19.2")
+    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.19.2")
+    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.19.2")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.19.2")
     implementation(kotlin("reflect"))
     implementation("org.apache.httpcomponents.core5:httpcore5:5.2.4")
     implementation("org.apache.httpcomponents.client5:httpclient5:5.3.1")


### PR DESCRIPTION
## Summary
Bumps Jackson dependencies from 2.18.2 to 2.19.2 across `anthropic-java-core/build.gradle.kts`.

## Motivation
Closes #296 — users who depend on this SDK are blocked from upgrading their own 
Jackson versions because the SDK pins 2.18.2. Bumping to the latest stable 2.19.2 
ensures users get recent bug fixes and security patches by default.

## Changes
Updated 6 Jackson dependencies in `anthropic-java-core/build.gradle.kts`:
- jackson-core
- jackson-databind
- jackson-annotations
- jackson-datatype-jdk8
- jackson-datatype-jsr310
- jackson-module-kotlin

Note: The `resolutionStrategy` block (pinned to 2.14.0 for backward compatibility 
testing) is intentionally left unchanged.

## Testing
- Build passes with `-x test`
- Note: this SDK appears to be Stainless-generated — maintainers should confirm 
  whether this change also needs to be applied upstream in the generator config.