### PR TITLE
fix: preserve code execution callers in toParam

### DIFF
--- a/anthropic-java-core/src/main/kotlin/com/anthropic/models/beta/messages/BetaServerToolUseBlock.kt
+++ b/anthropic-java-core/src/main/kotlin/com/anthropic/models/beta/messages/BetaServerToolUseBlock.kt
@@ -69,15 +69,15 @@ private constructor(
                             override fun visitCodeExecution20250825(
                                 codeExecution20250825: BetaServerToolCaller
                             ): BetaServerToolUseBlockParam.Caller =
-                                BetaServerToolUseBlockParam.Caller.ofDirect(
-                                    BetaDirectCaller.builder().build()
+                                BetaServerToolUseBlockParam.Caller.ofCodeExecution20250825(
+                                    codeExecution20250825
                                 )
 
                             override fun visitCodeExecution20260120(
                                 codeExecution20260120: BetaServerToolCaller20260120
                             ): BetaServerToolUseBlockParam.Caller =
-                                BetaServerToolUseBlockParam.Caller.ofDirect(
-                                    BetaDirectCaller.builder().build()
+                                BetaServerToolUseBlockParam.Caller.ofCodeExecution20260120(
+                                    codeExecution20260120
                                 )
                         }
                     )

--- a/anthropic-java-core/src/main/kotlin/com/anthropic/models/beta/messages/BetaToolUseBlock.kt
+++ b/anthropic-java-core/src/main/kotlin/com/anthropic/models/beta/messages/BetaToolUseBlock.kt
@@ -67,15 +67,15 @@ private constructor(
                             override fun visitCodeExecution20250825(
                                 codeExecution20250825: BetaServerToolCaller
                             ): BetaToolUseBlockParam.Caller =
-                                BetaToolUseBlockParam.Caller.ofDirect(
-                                    BetaDirectCaller.builder().build()
+                                BetaToolUseBlockParam.Caller.ofCodeExecution20250825(
+                                    codeExecution20250825
                                 )
 
                             override fun visitCodeExecution20260120(
                                 codeExecution20260120: BetaServerToolCaller20260120
                             ): BetaToolUseBlockParam.Caller =
-                                BetaToolUseBlockParam.Caller.ofDirect(
-                                    BetaDirectCaller.builder().build()
+                                BetaToolUseBlockParam.Caller.ofCodeExecution20260120(
+                                    codeExecution20260120
                                 )
                         }
                     )

--- a/anthropic-java-core/src/main/kotlin/com/anthropic/models/beta/messages/BetaWebFetchToolResultBlock.kt
+++ b/anthropic-java-core/src/main/kotlin/com/anthropic/models/beta/messages/BetaWebFetchToolResultBlock.kt
@@ -91,15 +91,15 @@ private constructor(
                             override fun visitCodeExecution20250825(
                                 codeExecution20250825: BetaServerToolCaller
                             ): BetaWebFetchToolResultBlockParam.Caller =
-                                BetaWebFetchToolResultBlockParam.Caller.ofDirect(
-                                    BetaDirectCaller.builder().build()
+                                BetaWebFetchToolResultBlockParam.Caller.ofCodeExecution20250825(
+                                    codeExecution20250825
                                 )
 
                             override fun visitCodeExecution20260120(
                                 codeExecution20260120: BetaServerToolCaller20260120
                             ): BetaWebFetchToolResultBlockParam.Caller =
-                                BetaWebFetchToolResultBlockParam.Caller.ofDirect(
-                                    BetaDirectCaller.builder().build()
+                                BetaWebFetchToolResultBlockParam.Caller.ofCodeExecution20260120(
+                                    codeExecution20260120
                                 )
                         }
                     )

--- a/anthropic-java-core/src/main/kotlin/com/anthropic/models/beta/messages/BetaWebSearchToolResultBlock.kt
+++ b/anthropic-java-core/src/main/kotlin/com/anthropic/models/beta/messages/BetaWebSearchToolResultBlock.kt
@@ -68,15 +68,15 @@ private constructor(
                             override fun visitCodeExecution20250825(
                                 codeExecution20250825: BetaServerToolCaller
                             ): BetaWebSearchToolResultBlockParam.Caller =
-                                BetaWebSearchToolResultBlockParam.Caller.ofDirect(
-                                    BetaDirectCaller.builder().build()
+                                BetaWebSearchToolResultBlockParam.Caller.ofCodeExecution20250825(
+                                    codeExecution20250825
                                 )
 
                             override fun visitCodeExecution20260120(
                                 codeExecution20260120: BetaServerToolCaller20260120
                             ): BetaWebSearchToolResultBlockParam.Caller =
-                                BetaWebSearchToolResultBlockParam.Caller.ofDirect(
-                                    BetaDirectCaller.builder().build()
+                                BetaWebSearchToolResultBlockParam.Caller.ofCodeExecution20260120(
+                                    codeExecution20260120
                                 )
                         }
                     )

--- a/anthropic-java-core/src/main/kotlin/com/anthropic/models/messages/ServerToolUseBlock.kt
+++ b/anthropic-java-core/src/main/kotlin/com/anthropic/models/messages/ServerToolUseBlock.kt
@@ -66,15 +66,15 @@ private constructor(
                             override fun visitCodeExecution20250825(
                                 codeExecution20250825: ServerToolCaller
                             ): ServerToolUseBlockParam.Caller =
-                                ServerToolUseBlockParam.Caller.ofDirect(
-                                    DirectCaller.builder().build()
+                                ServerToolUseBlockParam.Caller.ofCodeExecution20250825(
+                                    codeExecution20250825
                                 )
 
                             override fun visitCodeExecution20260120(
                                 codeExecution20260120: ServerToolCaller20260120
                             ): ServerToolUseBlockParam.Caller =
-                                ServerToolUseBlockParam.Caller.ofDirect(
-                                    DirectCaller.builder().build()
+                                ServerToolUseBlockParam.Caller.ofCodeExecution20260120(
+                                    codeExecution20260120
                                 )
                         }
                     )

--- a/anthropic-java-core/src/main/kotlin/com/anthropic/models/messages/ToolUseBlock.kt
+++ b/anthropic-java-core/src/main/kotlin/com/anthropic/models/messages/ToolUseBlock.kt
@@ -64,12 +64,16 @@ private constructor(
                             override fun visitCodeExecution20250825(
                                 codeExecution20250825: ServerToolCaller
                             ): ToolUseBlockParam.Caller =
-                                ToolUseBlockParam.Caller.ofDirect(DirectCaller.builder().build())
+                                ToolUseBlockParam.Caller.ofCodeExecution20250825(
+                                    codeExecution20250825
+                                )
 
                             override fun visitCodeExecution20260120(
                                 codeExecution20260120: ServerToolCaller20260120
                             ): ToolUseBlockParam.Caller =
-                                ToolUseBlockParam.Caller.ofDirect(DirectCaller.builder().build())
+                                ToolUseBlockParam.Caller.ofCodeExecution20260120(
+                                    codeExecution20260120
+                                )
                         }
                     )
                 }

--- a/anthropic-java-core/src/main/kotlin/com/anthropic/models/messages/WebFetchToolResultBlock.kt
+++ b/anthropic-java-core/src/main/kotlin/com/anthropic/models/messages/WebFetchToolResultBlock.kt
@@ -91,15 +91,15 @@ private constructor(
                             override fun visitCodeExecution20250825(
                                 codeExecution20250825: ServerToolCaller
                             ): WebFetchToolResultBlockParam.Caller =
-                                WebFetchToolResultBlockParam.Caller.ofDirect(
-                                    DirectCaller.builder().build()
+                                WebFetchToolResultBlockParam.Caller.ofCodeExecution20250825(
+                                    codeExecution20250825
                                 )
 
                             override fun visitCodeExecution20260120(
                                 codeExecution20260120: ServerToolCaller20260120
                             ): WebFetchToolResultBlockParam.Caller =
-                                WebFetchToolResultBlockParam.Caller.ofDirect(
-                                    DirectCaller.builder().build()
+                                WebFetchToolResultBlockParam.Caller.ofCodeExecution20260120(
+                                    codeExecution20260120
                                 )
                         }
                     )

--- a/anthropic-java-core/src/main/kotlin/com/anthropic/models/messages/WebSearchToolResultBlock.kt
+++ b/anthropic-java-core/src/main/kotlin/com/anthropic/models/messages/WebSearchToolResultBlock.kt
@@ -68,15 +68,15 @@ private constructor(
                             override fun visitCodeExecution20250825(
                                 codeExecution20250825: ServerToolCaller
                             ): WebSearchToolResultBlockParam.Caller =
-                                WebSearchToolResultBlockParam.Caller.ofDirect(
-                                    DirectCaller.builder().build()
+                                WebSearchToolResultBlockParam.Caller.ofCodeExecution20250825(
+                                    codeExecution20250825
                                 )
 
                             override fun visitCodeExecution20260120(
                                 codeExecution20260120: ServerToolCaller20260120
                             ): WebSearchToolResultBlockParam.Caller =
-                                WebSearchToolResultBlockParam.Caller.ofDirect(
-                                    DirectCaller.builder().build()
+                                WebSearchToolResultBlockParam.Caller.ofCodeExecution20260120(
+                                    codeExecution20260120
                                 )
                         }
                     )

--- a/anthropic-java-core/src/test/kotlin/com/anthropic/models/messages/CallerToParamTest.kt
+++ b/anthropic-java-core/src/test/kotlin/com/anthropic/models/messages/CallerToParamTest.kt
@@ -1,0 +1,96 @@
+// File generated from our OpenAPI spec by Stainless.
+
+package com.anthropic.models.messages
+
+import com.anthropic.core.jsonMapper
+import com.anthropic.models.beta.messages.BetaServerToolUseBlock
+import com.anthropic.models.beta.messages.BetaToolUseBlock
+import com.anthropic.models.beta.messages.BetaWebFetchToolResultBlock
+import com.anthropic.models.beta.messages.BetaWebSearchToolResultBlock
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.module.kotlin.jacksonTypeRef
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+internal class CallerToParamTest {
+
+    private val jsonMapper = jsonMapper()
+
+    private val callers =
+        listOf(
+            """{"type":"code_execution_20250825","tool_id":"srvtoolu_caller"}""",
+            """{"type":"code_execution_20260120","tool_id":"srvtoolu_caller"}""",
+        )
+
+    @Test
+    fun stableBlocksPreserveCodeExecutionCallers() {
+        callers.forEach { caller ->
+            assertCallerPreserved(
+                """{"type":"tool_use","id":"toolu_1","input":{},"name":"test","caller":<caller>}""",
+                caller,
+                jacksonTypeRef<ToolUseBlock>(),
+                ToolUseBlock::toParam,
+            )
+            assertCallerPreserved(
+                """{"type":"server_tool_use","id":"srvtoolu_1","input":{},"name":"web_search","caller":<caller>}""",
+                caller,
+                jacksonTypeRef<ServerToolUseBlock>(),
+                ServerToolUseBlock::toParam,
+            )
+            assertCallerPreserved(
+                """{"type":"web_search_tool_result","tool_use_id":"srvtoolu_1","content":{"type":"web_search_tool_result_error","error_code":"invalid_tool_input"},"caller":<caller>}""",
+                caller,
+                jacksonTypeRef<WebSearchToolResultBlock>(),
+                WebSearchToolResultBlock::toParam,
+            )
+            assertCallerPreserved(
+                """{"type":"web_fetch_tool_result","tool_use_id":"srvtoolu_1","content":{"type":"web_fetch_tool_result_error","error_code":"invalid_tool_input"},"caller":<caller>}""",
+                caller,
+                jacksonTypeRef<WebFetchToolResultBlock>(),
+                WebFetchToolResultBlock::toParam,
+            )
+        }
+    }
+
+    @Test
+    fun betaBlocksPreserveCodeExecutionCallers() {
+        callers.forEach { caller ->
+            assertCallerPreserved(
+                """{"type":"tool_use","id":"toolu_1","input":{},"name":"test","caller":<caller>}""",
+                caller,
+                jacksonTypeRef<BetaToolUseBlock>(),
+                BetaToolUseBlock::toParam,
+            )
+            assertCallerPreserved(
+                """{"type":"server_tool_use","id":"srvtoolu_1","input":{},"name":"web_search","caller":<caller>}""",
+                caller,
+                jacksonTypeRef<BetaServerToolUseBlock>(),
+                BetaServerToolUseBlock::toParam,
+            )
+            assertCallerPreserved(
+                """{"type":"web_search_tool_result","tool_use_id":"srvtoolu_1","content":{"type":"web_search_tool_result_error","error_code":"invalid_tool_input"},"caller":<caller>}""",
+                caller,
+                jacksonTypeRef<BetaWebSearchToolResultBlock>(),
+                BetaWebSearchToolResultBlock::toParam,
+            )
+            assertCallerPreserved(
+                """{"type":"web_fetch_tool_result","tool_use_id":"srvtoolu_1","content":{"type":"web_fetch_tool_result_error","error_code":"invalid_tool_input"},"caller":<caller>}""",
+                caller,
+                jacksonTypeRef<BetaWebFetchToolResultBlock>(),
+                BetaWebFetchToolResultBlock::toParam,
+            )
+        }
+    }
+
+    private fun <T> assertCallerPreserved(
+        block: String,
+        caller: String,
+        typeReference: TypeReference<T>,
+        toParam: (T) -> Any,
+    ) {
+        val response = jsonMapper.readValue(block.replace("<caller>", caller), typeReference)
+        val param = jsonMapper.readTree(jsonMapper.writeValueAsString(toParam(response)))
+
+        assertThat(param["caller"]).isEqualTo(jsonMapper.readTree(caller))
+    }
+}


### PR DESCRIPTION
## Summary

- preserve `code_execution_20250825` callers when response blocks are converted back to request params
- preserve `code_execution_20260120` callers instead of rewriting them to empty `direct` callers
- apply the fix to tool-use, server-tool-use, web-search-result, and web-fetch-result blocks in both stable and beta models
- add response-JSON replay regressions covering all eight block shapes and both caller versions

This addresses the caller-loss portion of #260. The existing `toParam()` visitors retained direct callers correctly, but silently converted code-execution callers into `DirectCaller.builder().build()`. That discarded the caller type and `tool_id` when assistant messages were replayed into a subsequent request.

## Validation

- `git diff --check`
- verified zero fabricated `DirectCaller.builder().build()` conversions remain in the eight affected response blocks
- verified all sixteen code-execution visitor branches now use their matching param caller variants

## Remote Linux validation
- `git diff --check`
- `./scripts/lint`
- `./scripts/build`
- `./scripts/test`