### PR TITLE
fix(http): avoid duplicate session events.send on timed-out retries

### DIFF
--- a/anthropic-java-core/src/main/kotlin/com/anthropic/core/http/RetryingHttpClient.kt
+++ b/anthropic-java-core/src/main/kotlin/com/anthropic/core/http/RetryingHttpClient.kt
@@ -33,7 +33,7 @@ private constructor(
 ) : HttpClient {
 
     override fun execute(request: HttpRequest, requestOptions: RequestOptions): HttpResponse {
-        var modifiedRequest = maybeAddIdempotencyHeader(request)
+        var modifiedRequest = prepareRequest(request)
 
         // Don't send the current retry count in the headers if the caller set their own value.
         val shouldSendRetryCount =
@@ -59,7 +59,7 @@ private constructor(
 
                     response
                 } catch (throwable: Throwable) {
-                    if (++retries > maxRetries || !shouldRetry(throwable)) {
+                    if (++retries > maxRetries || !shouldRetry(throwable, modifiedRequest)) {
                         throw throwable
                     }
 
@@ -77,7 +77,7 @@ private constructor(
         request: HttpRequest,
         requestOptions: RequestOptions,
     ): CompletableFuture<HttpResponse> {
-        val modifiedRequest = maybeAddIdempotencyHeader(request)
+        val modifiedRequest = prepareRequest(request)
 
         // Don't send the current retry count in the headers if the caller set their own value.
         val shouldSendRetryCount =
@@ -108,7 +108,9 @@ private constructor(
                                 return CompletableFuture.completedFuture(response)
                             }
                         } else {
-                            if (++retries > maxRetries || !shouldRetry(throwable!!)) {
+                            if (++retries > maxRetries ||
+                                !shouldRetry(throwable!!, requestWithRetryCount)
+                            ) {
                                 val failedFuture = CompletableFuture<HttpResponse>()
                                 failedFuture.completeExceptionally(throwable)
                                 return failedFuture
@@ -147,6 +149,25 @@ private constructor(
 
     private fun idempotencyKey(): String = "stainless-java-retry-${UUID.randomUUID()}"
 
+    /**
+     * Attach a stable idempotency header before the first attempt so retries reuse the same key.
+     *
+     * For [POST /v1/sessions/{id}/events][isSessionEventsMutation], always attach
+     * [IDEMPOTENCY_KEY_HEADER] (unless the caller already set it). Transport failures for that path
+     * are still not retried until the API documents server-side dedup for the header; the key
+     * remains useful for status-code retries and for future server support.
+     */
+    private fun prepareRequest(request: HttpRequest): HttpRequest {
+        var modified = maybeAddIdempotencyHeader(request)
+        if (isSessionEventsMutation(modified) &&
+            !modified.headers.names().contains(IDEMPOTENCY_KEY_HEADER)
+        ) {
+            modified =
+                modified.toBuilder().putHeader(IDEMPOTENCY_KEY_HEADER, idempotencyKey()).build()
+        }
+        return modified
+    }
+
     private fun maybeAddIdempotencyHeader(request: HttpRequest): HttpRequest {
         if (idempotencyHeader == null || request.headers.names().contains(idempotencyHeader)) {
             return request
@@ -157,6 +178,23 @@ private constructor(
             // Set a header to uniquely identify the request when retried.
             .putHeader(idempotencyHeader, idempotencyKey())
             .build()
+    }
+
+    /**
+     * `POST /v1/sessions/{session_id}/events` appends user/system turns. A timed-out client request
+     * that still landed server-side must not be retried blindly or the session sees a duplicated
+     * turn (see github.com/anthropics/anthropic-sdk-java/issues/370).
+     */
+    private fun isSessionEventsMutation(request: HttpRequest): Boolean {
+        if (request.method != HttpMethod.POST) {
+            return false
+        }
+        val segments = request.pathSegments
+        // Path is ["v1", "sessions", "{session_id}", "events"] (optional trailing segments ignored).
+        return segments.size >= 4 &&
+            segments[0] == "v1" &&
+            segments[1] == "sessions" &&
+            segments[3] == "events"
     }
 
     private fun shouldRetry(response: HttpResponse): Boolean {
@@ -181,11 +219,21 @@ private constructor(
         }
     }
 
-    private fun shouldRetry(throwable: Throwable): Boolean =
-        // Only retry known retryable exceptions, other exceptions are not intended to be retried.
-        throwable is IOException ||
-            throwable is AnthropicIoException ||
-            throwable is AnthropicRetryableException
+    private fun shouldRetry(throwable: Throwable, request: HttpRequest): Boolean {
+        // Explicitly marked retryable failures always retry.
+        if (throwable is AnthropicRetryableException) {
+            return true
+        }
+        if (throwable !is IOException && throwable !is AnthropicIoException) {
+            return false
+        }
+        // Timed-out-but-landed session event sends would duplicate user turns if retried.
+        // Refuse transport retries for that path; status-code retries still apply above.
+        if (isSessionEventsMutation(request)) {
+            return false
+        }
+        return true
+    }
 
     private fun getRetryBackoffDuration(retries: Int, response: HttpResponse?): Duration {
         // About the Retry-After header:
@@ -228,6 +276,9 @@ private constructor(
     }
 
     companion object {
+
+        /** Standard request-idempotency header attached to session event mutations. */
+        internal const val IDEMPOTENCY_KEY_HEADER = "Idempotency-Key"
 
         @JvmStatic fun builder() = Builder()
     }

--- a/anthropic-java-core/src/test/kotlin/com/anthropic/core/http/RetryingHttpClientTest.kt
+++ b/anthropic-java-core/src/test/kotlin/com/anthropic/core/http/RetryingHttpClientTest.kt
@@ -8,6 +8,7 @@ import com.anthropic.core.RequestOptions
 import com.anthropic.core.Sleeper
 import com.anthropic.errors.AnthropicRetryableException
 import com.github.tomakehurst.wiremock.client.WireMock.equalTo
+import com.github.tomakehurst.wiremock.client.WireMock.findAll
 import com.github.tomakehurst.wiremock.client.WireMock.matching
 import com.github.tomakehurst.wiremock.client.WireMock.ok
 import com.github.tomakehurst.wiremock.client.WireMock.post
@@ -20,6 +21,7 @@ import com.github.tomakehurst.wiremock.client.WireMock.verify
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo
 import com.github.tomakehurst.wiremock.junit5.WireMockTest
 import com.github.tomakehurst.wiremock.stubbing.Scenario
+import java.io.IOException
 import java.io.InputStream
 import java.time.Clock
 import java.time.Duration
@@ -27,7 +29,9 @@ import java.time.OffsetDateTime
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ExecutionException
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.parallel.ResourceLock
 import org.junit.jupiter.params.ParameterizedTest
@@ -152,6 +156,200 @@ internal class RetryingHttpClientTest {
         assertThat(response.statusCode()).isEqualTo(200)
         verify(1, postRequestedFor(urlPathEqualTo("/something")))
         assertThat(sleeper.durations).isEmpty()
+        assertNoResponseLeaks()
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = [false, true])
+    fun execute_sessionEventsSend_attachesIdempotencyKey(async: Boolean) {
+        stubFor(
+            post(urlPathEqualTo("/v1/sessions/sesn_test/events"))
+                .withHeader(
+                    RetryingHttpClient.IDEMPOTENCY_KEY_HEADER,
+                    matching("stainless-java-retry-.+"),
+                )
+                .willReturn(ok())
+        )
+        val sleeper = RecordingSleeper()
+        val retryingClient = retryingHttpClientBuilder(sleeper).maxRetries(2).build()
+
+        val response = retryingClient.execute(sessionEventsSendRequest(), async)
+
+        assertThat(response.statusCode()).isEqualTo(200)
+        verify(1, postRequestedFor(urlPathEqualTo("/v1/sessions/sesn_test/events")))
+        assertThat(sleeper.durations).isEmpty()
+        assertNoResponseLeaks()
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = [false, true])
+    fun execute_sessionEventsSend_preservesCallerIdempotencyKey(async: Boolean) {
+        stubFor(
+            post(urlPathEqualTo("/v1/sessions/sesn_test/events"))
+                .withHeader(RetryingHttpClient.IDEMPOTENCY_KEY_HEADER, equalTo("caller-key-1"))
+                .willReturn(ok())
+        )
+        val sleeper = RecordingSleeper()
+        val retryingClient = retryingHttpClientBuilder(sleeper).maxRetries(2).build()
+
+        val response =
+            retryingClient.execute(
+                sessionEventsSendRequest()
+                    .toBuilder()
+                    .putHeader(RetryingHttpClient.IDEMPOTENCY_KEY_HEADER, "caller-key-1")
+                    .build(),
+                async,
+            )
+
+        assertThat(response.statusCode()).isEqualTo(200)
+        verify(
+            1,
+            postRequestedFor(urlPathEqualTo("/v1/sessions/sesn_test/events"))
+                .withHeader(RetryingHttpClient.IDEMPOTENCY_KEY_HEADER, equalTo("caller-key-1")),
+        )
+        assertNoResponseLeaks()
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = [false, true])
+    fun execute_sessionEventsSend_reusesIdempotencyKeyOnStatusRetry(async: Boolean) {
+        stubFor(
+            post(urlPathEqualTo("/v1/sessions/sesn_test/events"))
+                .inScenario("session-events-status-retry")
+                .whenScenarioStateIs(Scenario.STARTED)
+                .willReturn(serviceUnavailable())
+                .willSetStateTo("RETRY")
+        )
+        stubFor(
+            post(urlPathEqualTo("/v1/sessions/sesn_test/events"))
+                .inScenario("session-events-status-retry")
+                .whenScenarioStateIs("RETRY")
+                .willReturn(ok())
+                .willSetStateTo("COMPLETED")
+        )
+        val sleeper = RecordingSleeper()
+        val retryingClient = retryingHttpClientBuilder(sleeper).maxRetries(2).build()
+
+        val response = retryingClient.execute(sessionEventsSendRequest(), async)
+
+        assertThat(response.statusCode()).isEqualTo(200)
+        verify(2, postRequestedFor(urlPathEqualTo("/v1/sessions/sesn_test/events")))
+        // Both attempts must share one Idempotency-Key (same value, not regenerated per attempt).
+        val keys =
+            findAll(postRequestedFor(urlPathEqualTo("/v1/sessions/sesn_test/events")))
+                .map { it.getHeader(RetryingHttpClient.IDEMPOTENCY_KEY_HEADER) }
+                .distinct()
+        assertThat(keys).hasSize(1)
+        assertThat(keys[0]).matches("stainless-java-retry-.+")
+        assertThat(sleeper.durations).hasSize(1)
+        assertNoResponseLeaks()
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = [false, true])
+    fun execute_sessionEventsSend_doesNotRetryTransportFailure(async: Boolean) {
+        var callCount = 0
+        val failingHttpClient =
+            object : HttpClient {
+                override fun execute(
+                    request: HttpRequest,
+                    requestOptions: RequestOptions,
+                ): HttpResponse {
+                    callCount++
+                    throw IOException("simulated client timeout after request may have landed")
+                }
+
+                override fun executeAsync(
+                    request: HttpRequest,
+                    requestOptions: RequestOptions,
+                ): CompletableFuture<HttpResponse> {
+                    callCount++
+                    val future = CompletableFuture<HttpResponse>()
+                    future.completeExceptionally(
+                        IOException("simulated client timeout after request may have landed")
+                    )
+                    return future
+                }
+
+                override fun close() {}
+            }
+        val sleeper = RecordingSleeper()
+        val retryingClient =
+            RetryingHttpClient.builder()
+                .httpClient(failingHttpClient)
+                .maxRetries(3)
+                .sleeper(sleeper)
+                .build()
+
+        if (async) {
+            assertThatThrownBy { retryingClient.executeAsync(sessionEventsSendRequest()).get() }
+                .isInstanceOf(ExecutionException::class.java)
+                .hasCauseInstanceOf(IOException::class.java)
+        } else {
+            assertThatThrownBy { retryingClient.execute(sessionEventsSendRequest()) }
+                .isInstanceOf(IOException::class.java)
+        }
+
+        // One attempt only — retrying would risk a duplicated session user turn.
+        assertThat(callCount).isEqualTo(1)
+        assertThat(sleeper.durations).isEmpty()
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = [false, true])
+    fun execute_otherPost_retriesTransportFailure(async: Boolean) {
+        stubFor(post(urlPathEqualTo("/v1/messages")).willReturn(ok()))
+
+        var callCount = 0
+        val flakyHttpClient =
+            object : HttpClient {
+                override fun execute(
+                    request: HttpRequest,
+                    requestOptions: RequestOptions,
+                ): HttpResponse {
+                    callCount++
+                    if (callCount == 1) {
+                        throw IOException("transient network blip")
+                    }
+                    return httpClient.execute(request, requestOptions)
+                }
+
+                override fun executeAsync(
+                    request: HttpRequest,
+                    requestOptions: RequestOptions,
+                ): CompletableFuture<HttpResponse> {
+                    callCount++
+                    if (callCount == 1) {
+                        val future = CompletableFuture<HttpResponse>()
+                        future.completeExceptionally(IOException("transient network blip"))
+                        return future
+                    }
+                    return httpClient.executeAsync(request, requestOptions)
+                }
+
+                override fun close() = httpClient.close()
+            }
+        val sleeper = RecordingSleeper()
+        val retryingClient =
+            RetryingHttpClient.builder()
+                .httpClient(flakyHttpClient)
+                .maxRetries(2)
+                .sleeper(sleeper)
+                .build()
+
+        val response =
+            retryingClient.execute(
+                HttpRequest.builder()
+                    .method(HttpMethod.POST)
+                    .baseUrl(baseUrl)
+                    .addPathSegments("v1", "messages")
+                    .build(),
+                async,
+            )
+
+        assertThat(response.statusCode()).isEqualTo(200)
+        assertThat(callCount).isEqualTo(2)
+        assertThat(sleeper.durations).hasSize(1)
         assertNoResponseLeaks()
     }
 
@@ -502,6 +700,13 @@ internal class RetryingHttpClientTest {
         sleeper: RecordingSleeper,
         clock: Clock = Clock.systemUTC(),
     ) = RetryingHttpClient.builder().httpClient(httpClient).sleeper(sleeper).clock(clock)
+
+    private fun sessionEventsSendRequest(): HttpRequest =
+        HttpRequest.builder()
+            .method(HttpMethod.POST)
+            .baseUrl(baseUrl)
+            .addPathSegments("v1", "sessions", "sesn_test", "events")
+            .build()
 
     private fun HttpClient.execute(request: HttpRequest, async: Boolean): HttpResponse =
         if (async) executeAsync(request).get() else execute(request)


### PR DESCRIPTION
## Summary

`RetryingHttpClient` could retry `POST /v1/sessions/{session_id}/events` after a client-side timeout even when the request had already landed server-side, producing a duplicated user turn (and a second model turn) in the session.

### Changes

1. **Stable `Idempotency-Key`** – automatically attach `Idempotency-Key: stainless-java-retry-<uuid>` to session event mutations (unless the caller already set one). The same key is reused across status-code retries.
2. **No transport retries for session event POSTs** – `IOException` / `AnthropicIoException` (including timed-out-but-possibly-landed requests) are **not** retried for this path. Explicit `AnthropicRetryableException` still retries.
3. **Status-code retries unchanged** – 408/409/429/5xx still retry and keep the same idempotency key.

Caller-supplied `Idempotency-Key` values are preserved.

Full server-side dedup for `Idempotency-Key` on this endpoint is still desirable for status-code retries after partial processing; this PR makes the client safe for the observed timeout case without requiring API changes.

Fixes #370

## Test plan

- [x] `./gradlew :anthropic-java-core:test --tests 'com.anthropic.core.http.RetryingHttpClientTest'` (JDK 21) — **30/30 green**
  - attaches `Idempotency-Key` to session events send
  - preserves caller-provided key
  - reuses the same key across 503 retries
  - does **not** retry transport failure for session events send
  - still retries transport failure for other POSTs (e.g. `/v1/messages`)
- [ ] CI