### PR TITLE
fix(client): encode path segments as path segments, and reject dot-segments

### DIFF
--- a/anthropic-java-core/src/main/kotlin/com/anthropic/core/http/HttpRequest.kt
+++ b/anthropic-java-core/src/main/kotlin/com/anthropic/core/http/HttpRequest.kt
@@ -68,13 +68,23 @@ private constructor(
          * Encodes one path segment.
          *
          * [URLEncoder] implements `application/x-www-form-urlencoded`, which is the right encoding
-         * for a query string but differs from an RFC 3986 path segment in one way that reaches the
-         * wire: a space becomes `+`, which a path reader sees as a literal plus rather than as a
-         * space, so `"a b"` currently addresses a resource named `a+b`.
+         * for a query string but differs from an RFC 3986 path segment in two ways that reach the
+         * wire:
+         * - A space becomes `+`, which a path reader sees as a literal plus rather than as a space,
+         *   so `"a b"` addresses a resource named `a+b`.
+         * - `.` is in its safe set, so a segment of `"."` or `".."` passes through unencoded and URI
+         *   normalization then resolves it away, changing which path the request is sent to. A
+         *   parameter identifies a resource; it should not be able to move the request. These are
+         *   rejected rather than encoded, matching the Python SDK, whose `path_template` raises for
+         *   dot-segments, and the TypeScript SDK, whose `path` tagged template throws.
          *
          * Query parameter encoding is deliberately left alone, since `URLEncoder` is correct there.
          */
         private fun encodePathSegment(segment: String): String {
+            require(segment != "." && segment != "..") {
+                "Path segment must not be \".\" or \"..\", but got \"$segment\". Such a segment is " +
+                    "resolved away by URI normalization and would change the request's path."
+            }
             return URLEncoder.encode(segment, "UTF-8").replace("+", "%20")
         }
     }

--- a/anthropic-java-core/src/main/kotlin/com/anthropic/core/http/HttpRequest.kt
+++ b/anthropic-java-core/src/main/kotlin/com/anthropic/core/http/HttpRequest.kt
@@ -23,7 +23,7 @@ private constructor(
             if (!endsWith("/")) {
                 append("/")
             }
-            append(URLEncoder.encode(segment, "UTF-8"))
+            append(encodePathSegment(segment))
         }
 
         if (queryParams.isEmpty()) {
@@ -63,6 +63,20 @@ private constructor(
 
     companion object {
         @JvmStatic fun builder() = Builder()
+
+        /**
+         * Encodes one path segment.
+         *
+         * [URLEncoder] implements `application/x-www-form-urlencoded`, which is the right encoding
+         * for a query string but differs from an RFC 3986 path segment in one way that reaches the
+         * wire: a space becomes `+`, which a path reader sees as a literal plus rather than as a
+         * space, so `"a b"` currently addresses a resource named `a+b`.
+         *
+         * Query parameter encoding is deliberately left alone, since `URLEncoder` is correct there.
+         */
+        private fun encodePathSegment(segment: String): String {
+            return URLEncoder.encode(segment, "UTF-8").replace("+", "%20")
+        }
     }
 
     class Builder internal constructor() {

--- a/anthropic-java-core/src/test/kotlin/com/anthropic/core/http/HttpRequestTest.kt
+++ b/anthropic-java-core/src/test/kotlin/com/anthropic/core/http/HttpRequestTest.kt
@@ -197,6 +197,26 @@ internal class HttpRequestTest {
             expectedUrl =
                 "https://api.example.com/v1/users/123?include=profile&include=settings&format=json",
         ),
+        PATH_SEGMENT_WITH_SPACE(
+            HttpRequest.builder()
+                .method(HttpMethod.GET)
+                .baseUrl("https://api.example.com")
+                .addPathSegments("v1", "models", "a b")
+                .build(),
+            // A path segment is not form-encoded, so a space is "%20". "+" would address a
+            // resource whose name contains a literal plus.
+            expectedUrl = "https://api.example.com/v1/models/a%20b",
+        ),
+        PATH_SEGMENT_WITH_RESERVED_CHARS(
+            HttpRequest.builder()
+                .method(HttpMethod.GET)
+                .baseUrl("https://api.example.com")
+                .addPathSegments("v1", "models", "a/b@c")
+                .build(),
+            // Guards against loosening: a segment must never be able to introduce a new path
+            // segment or a userinfo component.
+            expectedUrl = "https://api.example.com/v1/models/a%2Fb%40c",
+        ),
     }
 
     @ParameterizedTest
@@ -206,4 +226,5 @@ internal class HttpRequestTest {
 
         assertThat(actualUrl).isEqualTo(testCase.expectedUrl)
     }
+
 }

--- a/anthropic-java-core/src/test/kotlin/com/anthropic/core/http/HttpRequestTest.kt
+++ b/anthropic-java-core/src/test/kotlin/com/anthropic/core/http/HttpRequestTest.kt
@@ -2,9 +2,11 @@ package com.anthropic.core.http
 
 import java.io.OutputStream
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
+import org.junit.jupiter.params.provider.ValueSource
 
 internal class HttpRequestTest {
 
@@ -227,4 +229,20 @@ internal class HttpRequestTest {
         assertThat(actualUrl).isEqualTo(testCase.expectedUrl)
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = [".", ".."])
+    fun urlRejectsDotSegments(segment: String) {
+        val request =
+            HttpRequest.builder()
+                .method(HttpMethod.GET)
+                .baseUrl("https://api.example.com")
+                .addPathSegments("v1", "messages", segment, "results")
+                .build()
+
+        // Without this, URI normalization resolves the segment away and the request is sent to
+        // "https://api.example.com/v1/messages/results" instead.
+        assertThatThrownBy { request.url() }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining(segment)
+    }
 }


### PR DESCRIPTION
## What

Two small corrections to how `HttpRequest.url()` encodes **path** segments. Query parameter
encoding is untouched.

`url()` encodes every path segment with `java.net.URLEncoder.encode`, which implements
`application/x-www-form-urlencoded`. That is the right encoding for a query string, but it differs
from an RFC 3986 path segment in two ways that reach the wire.

**1. A space becomes `+`.** In a path, `+` is a literal plus rather than a space, so
`models().retrieve("a b")` requests `/v1/models/a+b` — a resource whose name contains a plus.

**2. `.` is in `URLEncoder`'s safe set**, so a segment of `"."` or `".."` passes through unencoded
and URI normalization resolves it away — sending the request to a different path than the method
that was called. Verified against a loopback server, so these are the paths the server actually
receives:

| call | path received today |
|---|---|
| `messages().batches().resultsStreaming("msgbatch_1")` | `GET /v1/messages/batches/msgbatch_1/results` |
| `messages().batches().resultsStreaming("..")` | `GET /v1/messages/results` |
| `messages().batches().delete("..")` | `DELETE /v1/messages/` |
| `models().retrieve("..")` | `GET /v1/` |

A path parameter identifies a resource; it should not be able to move the request. This rejects
those two values rather than encoding them, which matches the sibling SDKs — Python's
`path_template` raises `ValueError` for dot-segments, and TypeScript's `path` tagged template
throws `AnthropicError`. If you would rather encode than throw, that is a one-line change to the
same helper; I went with the family behaviour.

## Scope, and what deliberately did not change

- **Only the space encoding changes.** Every other character encodes identically. The new
  `PATH_SEGMENT_WITH_RESERVED_CHARS` case pins `a/b@c` → `a%2Fb%40c`, which is the same before and
  after, so a segment still cannot introduce a path separator or a userinfo component.
- **Query parameters are untouched.** `URLEncoder` is correct there, and the existing
  `QUERY_PARAM_WITH_SPECIAL_CHARS` case still asserts `q=hello+world`.
- **`:` is left encoded as `%3A`.** RFC 3986 permits `:` in a path segment, and real model ids
  contain one — `anthropic.claude-sonnet-5-v1:0` currently becomes
  `anthropic.claude-sonnet-5-v1%3A0`. Since `BedrockBackend` and `VertexBackend` put model ids in
  the path and SigV4 signing runs after that rewrite, changing it did not feel like something to
  fold into this PR. Flagging it in case it is worth a separate look.
- **Percent-encoded forms need no extra handling.** `URLEncoder` escapes the `%`, so a segment of
  `"%2e%2e"` already becomes `"%252e%252e"`.
- Validation happens at encode time so every construction path is covered. Moving it into
  `Builder.addPathSegment` would fail faster and point at the caller — happy to do that instead if
  you prefer.

## Bounds on the second issue

Only a segment that is *exactly* `..` traverses. `"../.."` is already safe because the `/` is
encoded, so the effect is one path component per parameter, and a `baseUrl` path prefix cannot be
escaped — I measured `/anthropic` and `/tenants/acme/anthropic` prefixes and every payload stayed
inside the prefix.

I raised this through the security process first; Anthropic assessed it as outside the threat model
on the grounds that resource ids come from the application rather than from an attacker. That seems
right to me, so this PR is purely the correctness half — no security claim.

## Testing

Two cases added to the existing `UrlTestCase` table and one parameterised test for the rejection.
