### PR TITLE
fix(messages): make Message.toParam() produce a readable role

### DIFF
--- a/anthropic-java-core/src/main/kotlin/com/anthropic/models/messages/Message.kt
+++ b/anthropic-java-core/src/main/kotlin/com/anthropic/models/messages/Message.kt
@@ -74,7 +74,9 @@ private constructor(
     fun toParam(): MessageParam =
         MessageParam.builder()
             .content(_content().map { MessageParam.Content.ofBlockParams(it.map { it.toParam() }) })
-            .role(_role())
+            .role(
+                _role().asString().map(MessageParam.Role::of).orElse(MessageParam.Role.ASSISTANT)
+            )
             .build()
 
     /**

--- a/anthropic-java-core/src/test/kotlin/com/anthropic/models/messages/MessageTest.kt
+++ b/anthropic-java-core/src/test/kotlin/com/anthropic/models/messages/MessageTest.kt
@@ -205,4 +205,74 @@ internal class MessageTest {
 
         assertThat(roundtrippedMessage).isEqualTo(message)
     }
+
+    @Test
+    fun toParamProducesAReadableRole() {
+        val message =
+            Message.builder()
+                .id("msg_013Zva2CMHLNnXjNJJKqJ2EF")
+                .container(
+                    Container.builder()
+                        .id("container_011CpZohnwH4vuy7gazohgSP")
+                        .expiresAt(OffsetDateTime.parse("2019-12-27T18:11:19.117Z"))
+                        .build()
+                )
+                .addContent(
+                    TextBlock.builder()
+                        .addCitation(
+                            CitationCharLocation.builder()
+                                .citedText("The grass is green. The sky is blue.")
+                                .documentIndex(0L)
+                                .documentTitle("My Document")
+                                .endCharIndex(0L)
+                                .fileId("file_011CNha8iCJcU1wXNR6q4V8w")
+                                .startCharIndex(0L)
+                                .build()
+                        )
+                        .text("Hi! My name is Claude.")
+                        .build()
+                )
+                .model(Model.CLAUDE_OPUS_4_6)
+                .stopDetails(
+                    RefusalStopDetails.builder()
+                        .category(RefusalStopDetails.Category.CYBER)
+                        .explanation(
+                            "This request was declined because it conflicts with Anthropic's Usage Policy."
+                        )
+                        .build()
+                )
+                .stopReason(StopReason.END_TURN)
+                .stopSequence(null)
+                .usage(
+                    Usage.builder()
+                        .cacheCreation(
+                            CacheCreation.builder()
+                                .ephemeral1hInputTokens(0L)
+                                .ephemeral5mInputTokens(0L)
+                                .build()
+                        )
+                        .cacheCreationInputTokens(2051L)
+                        .cacheReadInputTokens(2051L)
+                        .inferenceGeo("global")
+                        .inputTokens(2095L)
+                        .outputTokens(503L)
+                        .outputTokensDetails(
+                            OutputTokensDetails.builder().thinkingTokens(0L).build()
+                        )
+                        .serverToolUse(
+                            ServerToolUsage.builder()
+                                .webFetchRequests(2L)
+                                .webSearchRequests(0L)
+                                .build()
+                        )
+                        .serviceTier(Usage.ServiceTier.STANDARD)
+                        .build()
+                )
+                .build()
+
+
+        val param = message.toParam()
+
+        assertThat(param.role()).isEqualTo(MessageParam.Role.ASSISTANT)
+    }
 }


### PR DESCRIPTION
## The problem

`Message.toParam()` returns a `MessageParam` whose own `role()` accessor rejects the value `toParam()` just wrote:

```
com.anthropic.errors.AnthropicInvalidDataException: `role` is invalid, received assistant
```

`assistant` is of course a valid `MessageParam.Role`.

## Why

The two sides declare `role` differently:

| | declaration |
|---|---|
| `Message.role` | `JsonValue` — a raw JSON string, always `"assistant"` |
| `MessageParam.role` | `JsonField<Role>` — a typed field |

`toParam()` did `.role(_role())`, putting the raw value into the typed slot. `MessageParam.role()` then calls `role.getRequired("role")`, which cannot read it back as a `Role`.

Serialization is unaffected — the wire JSON is correct — so this only surfaces on the typed accessor, which is likely why it has gone unnoticed. It shows up for anyone appending an assistant turn back into a conversation and then inspecting it, which is the normal shape of a tool-use loop:

```java
conversation.add(response.toParam());
// ...later
param.role();   // throws
```

## The fix

Convert the raw value to a `MessageParam.Role`, falling back to `ASSISTANT`, which a `Message` always is.

```kotlin
.role(
    _role().asString().map(MessageParam.Role::of).orElse(MessageParam.Role.ASSISTANT)
)
```

## Verification

`./scripts/test` with the Steady mock server running (`./scripts/mock --daemon`):

| | tests | failures |
|---|---|---|
| `main` | 5305 | 0 |
| this branch | 5306 | 0 |

Fully green — one test added, no regressions.

## Note

Both files carry the Stainless generated-code header. CONTRIBUTING says modifications are persisted between generations, so I've patched them directly — happy to move the test somewhere less likely to conflict if you'd prefer, or to route the fix through the generator instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)