### PR TITLE
fix(messages): send an empty object when an accumulated tool_use has no input

### DIFF
--- a/anthropic-java-core/src/main/kotlin/com/anthropic/models/beta/messages/BetaMcpToolUseBlock.kt
+++ b/anthropic-java-core/src/main/kotlin/com/anthropic/models/beta/messages/BetaMcpToolUseBlock.kt
@@ -41,7 +41,10 @@ private constructor(
     fun toParam(): BetaMcpToolUseBlockParam =
         BetaMcpToolUseBlockParam.builder()
             .id(_id())
-            .input(_input())
+            // A tool that declares no parameters streams only an empty `input_json_delta`, so an
+            // accumulated block can carry a missing `input` (see #249). `input` is required on the
+            // way back in, so send the empty object it must be.
+            .input(if (_input().isMissing()) JsonValue.from(emptyMap<String, Any>()) else _input())
             .name(_name())
             .serverName(_serverName())
             .build()

--- a/anthropic-java-core/src/main/kotlin/com/anthropic/models/beta/messages/BetaServerToolUseBlock.kt
+++ b/anthropic-java-core/src/main/kotlin/com/anthropic/models/beta/messages/BetaServerToolUseBlock.kt
@@ -52,7 +52,10 @@ private constructor(
     fun toParam(): BetaServerToolUseBlockParam =
         BetaServerToolUseBlockParam.builder()
             .id(_id())
-            .input(_input())
+            // A tool that declares no parameters streams only an empty `input_json_delta`, so an
+            // accumulated block can carry a missing `input` (see #249). `input` is required on the
+            // way back in, so send the empty object it must be.
+            .input(if (_input().isMissing()) JsonValue.from(emptyMap<String, Any>()) else _input())
             .name(_name().map { BetaServerToolUseBlockParam.Name.of(it.toString()) })
             .caller(
                 _caller().map {

--- a/anthropic-java-core/src/main/kotlin/com/anthropic/models/beta/messages/BetaToolUseBlock.kt
+++ b/anthropic-java-core/src/main/kotlin/com/anthropic/models/beta/messages/BetaToolUseBlock.kt
@@ -53,7 +53,10 @@ private constructor(
     fun toParam(): BetaToolUseBlockParam =
         BetaToolUseBlockParam.builder()
             .id(_id())
-            .input(_input())
+            // A tool that declares no parameters streams only an empty `input_json_delta`, so an
+            // accumulated block can carry a missing `input` (see #249). `input` is required on the
+            // way back in, so send the empty object it must be.
+            .input(if (_input().isMissing()) JsonValue.from(emptyMap<String, Any>()) else _input())
             .name(_name())
             .caller(
                 _caller().map {

--- a/anthropic-java-core/src/main/kotlin/com/anthropic/models/messages/ServerToolUseBlock.kt
+++ b/anthropic-java-core/src/main/kotlin/com/anthropic/models/messages/ServerToolUseBlock.kt
@@ -52,7 +52,10 @@ private constructor(
     fun toParam(): ServerToolUseBlockParam =
         ServerToolUseBlockParam.builder()
             .id(_id())
-            .input(_input())
+            // A tool that declares no parameters streams only an empty `input_json_delta`, so an
+            // accumulated block can carry a missing `input` (see #249). `input` is required on the
+            // way back in, so send the empty object it must be.
+            .input(if (_input().isMissing()) JsonValue.from(emptyMap<String, Any>()) else _input())
             .name(_name().map { ServerToolUseBlockParam.Name.of(it.toString()) })
             .caller(
                 _caller().map {

--- a/anthropic-java-core/src/main/kotlin/com/anthropic/models/messages/ToolUseBlock.kt
+++ b/anthropic-java-core/src/main/kotlin/com/anthropic/models/messages/ToolUseBlock.kt
@@ -51,7 +51,11 @@ private constructor(
     fun toParam(): ToolUseBlockParam =
         ToolUseBlockParam.builder()
             .id(_id())
-            .input(_input())
+            // A tool that declares no parameters streams only an empty `input_json_delta`, so an
+            // accumulated `Message` can carry a missing `input` (see #249). `tool_use.input` is
+            // required on the way back in, so send the empty object the API itself sent us in
+            // `content_block_start`.
+            .input(if (_input().isMissing()) JsonValue.from(emptyMap<String, Any>()) else _input())
             .name(_name())
             .caller(
                 _caller().map {

--- a/anthropic-java-core/src/test/kotlin/com/anthropic/helpers/MessageAccumulatorTest.kt
+++ b/anthropic-java-core/src/test/kotlin/com/anthropic/helpers/MessageAccumulatorTest.kt
@@ -661,6 +661,30 @@ internal class MessageAccumulatorTest {
     }
 
     @Test
+    fun accumulateToolUseContentBlockWithNoInputCanBeSentBackToTheApi() {
+        val accumulator = MessageAccumulator.create()
+
+        accumulator.accumulate(messageStartEvent())
+        accumulator.accumulate(toolUseContentBlockStartEvent(1L, "1-TOOL."))
+        // A tool that declares no parameters streams no input JSON at all.
+        accumulator.accumulate(toolUseContentBlockDeltaEvent(1L, ""))
+        accumulator.accumulate(contentBlockStopEvent(1L))
+        accumulator.accumulate(
+            messageDeltaEvent(stopReason = JsonField.of(StopReason.TOOL_USE), outputTokens = 88L)
+        )
+        accumulator.accumulate(messageStopEvent())
+
+        // Appending the assistant turn back into the conversation is the normal
+        // shape of a tool-use loop. The Messages API requires `tool_use.input`,
+        // so a param whose `input` is missing is rejected with a 400:
+        //   messages.N.content.M.tool_use.input: Field required
+        val toolUse =
+            accumulator.message().toParam().content().blockParams().get()[0].asToolUse()
+
+        assertThat(toolUse._input().asObject().get()).isEmpty()
+    }
+
+    @Test
     fun accumulateTextAndToolUseContentBlocks() {
         val accumulator = MessageAccumulator.create()
 


### PR DESCRIPTION
Tools that declare no parameters produce a `Message` that cannot be sent back to the API. This is the conservative of two possible fixes; **the alternative is #382**, which I think is actually the better one — I'd be glad to close whichever you like less.

## Reproduction

A tool with an empty input schema:

```json
{"name":"run_tests","input_schema":{"type":"object","properties":{},"required":[]}}
```

Streaming, the block arrives like this — captured with `ANTHROPIC_LOG=debug`:

```
content_block_start  {"type":"tool_use","id":"toolu_013Ac...","name":"run_tests","input":{},"caller":{"type":"direct"}}
content_block_delta  {"type":"input_json_delta","partial_json":""}
content_block_stop
```

Every `tool_use` block opens with an empty `input_json_delta`; a tool *with* arguments then gets its real fragments. For a zero-argument tool that empty delta is the only one, so the accumulated JSON is `""` and `MessageAccumulator` records `input` as `JsonMissing` — the behavior introduced for #249 and asserted by `accumulateToolUseContentBlockWithNoInput`.

**This PR leaves that alone.** Recording "no input JSON was streamed" on a `Message` is defensible; the problem is what happens when that `Message` is converted back into a request.

## The failure

Appending the assistant turn to the conversation is the normal shape of a tool-use loop. `toParam()` copies the missing `input` through:

```kotlin
fun toParam(): ToolUseBlockParam =
    ToolUseBlockParam.builder()
        .id(_id())
        .input(_input())     // "missing" into a required field
```

and the next request is rejected:

```json
{"id":"toolu_013Ac...","name":"run_tests","type":"tool_use","caller":{"type":"direct"}}
```
```
400 messages.1.content.2.tool_use.input: Field required
```

A `list_dir` block in the same request body serializes correctly as `"input":{"path":"."}`, so the conversion is only wrong for the absent case.

## The change

Normalize at the boundary, in all five `toParam()` sites that share the pattern — `ToolUseBlock`, `ServerToolUseBlock`, `BetaToolUseBlock`, `BetaServerToolUseBlock`, `BetaMcpToolUseBlock`:

```kotlin
.input(if (_input().isMissing()) JsonValue.from(emptyMap<String, Any>()) else _input())
```

The justification is the API's own contract, quoted in the accumulator's comment: *"the final `tool_use.input` is always an object."* A `Message` may represent absence; a request may not.

**No existing test changes.** Adds `accumulateToolUseContentBlockWithNoInputCanBeSentBackToTheApi`, which fails on `main` and passes here.

## What this does not fix

`BetaToolRunner` reads the value directly rather than going through `toParam()`:

```kotlin
tool.run(toolUse._input())
```

and a runnable tool calls `outputTypeFromJson(toJsonString(input), ...)`, where `toJsonString` on `JsonMissing` throws from `Values.kt:452` — `IllegalStateException: JsonMissing cannot be serialized`. So with this PR, a zero-argument tool still fails under the built-in tool runner.

**#382 fixes both**, at the cost of changing two deliberate assertions. That is the real tradeoff between the two, and it is why I'd lean toward #382.

I also checked whether anything relies on the missing-ness: nothing in `main/kotlin` branches on a tool input being missing.

## Verification

`./scripts/test` with the Steady mock server running (`./scripts/mock --daemon`):

| | tests | failures |
|---|---|---|
| `main` | 5305 | 0 |
| this branch | 5306 | 0 |

Fully green — one test added, no regressions.

## Note

These files carry the Stainless generated-code header. CONTRIBUTING says modifications are persisted between generations, so I've patched them directly — happy to route this through the generator instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
