### PR TITLE
docs(contributing): describe the mock server the scripts actually run

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,15 +31,27 @@ $ ./gradlew :anthropic-java-example:run
 
 ## Running tests
 
-Most tests require you to [set up a mock server](https://github.com/stoplightio/prism) against the OpenAPI spec to run the tests.
-
-```sh
-$ npx prism mock path/to/your/openapi.yml
-```
+Most tests run against a mock server generated from the OpenAPI spec. `./scripts/test` starts
+one for you and shuts it down when it finishes, so usually there is nothing to set up:
 
 ```sh
 $ ./scripts/test
 ```
+
+The spec URL is read from `.stats.yml`, so no path is needed.
+
+To keep a server running across several test runs, start it yourself first — `./scripts/test`
+will detect it and reuse it:
+
+```sh
+$ ./scripts/mock --daemon   # background, on 127.0.0.1:4010
+$ ./scripts/mock            # or in the foreground
+```
+
+To run against something other than the mock server, set `TEST_API_BASE_URL`.
+
+Without a mock server the suite does not merely fail — a large number of tests never run at all,
+so a green result is not meaningful. Check that the count looks complete.
 
 The `anthropic-java-ecosystem-test` module verifies that the SDK still works for downstream
 consumers: it runs ProGuard/R8 shrinking checks, executes a Java consumer on a real Java 8 runtime,


### PR DESCRIPTION
`CONTRIBUTING.md` tells contributors to run Prism:

```sh
$ npx prism mock path/to/your/openapi.yml
```

That is no longer what the repo does. `scripts/mock` runs **Steady** (`@stdy/cli@0.22.2`) on `127.0.0.1:4010` and reads the spec URL from `.stats.yml`, so no path argument is needed. `scripts/test` starts it as a daemon, waits on `/_x-steady/health`, reuses an already-running server if it finds one, and kills it on exit.

Following the instructions literally gets you a server that the test suite does not look for. Running `./scripts/test` just works, and the docs never say so.

## Why it is worth fixing

Without a mock server the suite does not simply fail — a large number of tests never execute:

| | tests run | failures |
|---|---|---|
| no mock server | 5097 | 62 |
| `./scripts/test` | 5305 | 0 |

208 tests are silently skipped. A contributor who follows CONTRIBUTING, sees the same 62 failures before and after their change, and concludes "pre-existing, unrelated" has actually verified far less than they think. I did exactly that on an earlier PR before working out what the scripts do.

## The change

Rewrites the "Running tests" section to describe the scripts as they are: `./scripts/test` as the normal path, `./scripts/mock [--daemon]` for keeping a server across runs, `TEST_API_BASE_URL` for pointing elsewhere, and a note that a green run without a server is not meaningful.

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)