### PR TITLE
build: add Automatic-Module-Name to all published jars

### DIFF
--- a/buildSrc/src/main/kotlin/anthropic.publish.gradle.kts
+++ b/buildSrc/src/main/kotlin/anthropic.publish.gradle.kts
@@ -22,6 +22,44 @@ publishing {
   }
 }
 
+// JPMS module names for the published jars, kept in one place so the namespace stays visible and
+// collision-free. Each name is the root package of the module carrying it, so a future
+// `module-info.java` can declare the very same name; `anthropic-java-core` therefore takes
+// `com.anthropic` outright, since it owns every package under it. `anthropic-java` ships no classes
+// of its own — it only re-exports `anthropic-java-core` and `anthropic-java-client-okhttp` — so it
+// has no root package to name it after and sits beside them instead.
+val automaticModuleNames = mapOf(
+    "anthropic-java" to "com.anthropic.all",
+    "anthropic-java-aws" to "com.anthropic.aws",
+    "anthropic-java-bedrock" to "com.anthropic.bedrock",
+    "anthropic-java-client-okhttp" to "com.anthropic.client.okhttp",
+    "anthropic-java-core" to "com.anthropic",
+    "anthropic-java-foundry" to "com.anthropic.foundry",
+    "anthropic-java-google-cloud" to "com.anthropic.googlecloud",
+    "anthropic-java-mcp" to "com.anthropic.mcp",
+    "anthropic-java-vertex" to "com.anthropic.vertex",
+)
+
+// Without this attribute a consumer on the module path gets a module name derived from the jar's
+// file name, which is neither stable nor ours to choose. A published module missing from the map
+// above fails the build rather than falling back to a derived name: the name is a compatibility
+// promise that can't be changed after a release, so it has to be picked deliberately, once, before
+// the module's first publish.
+plugins.withType<JavaPlugin> {
+    val automaticModuleName =
+        automaticModuleNames[project.name]
+            ?: error(
+                "No Automatic-Module-Name is declared for published module '${project.name}'. " +
+                    "Add one to `automaticModuleNames` in `anthropic.publish.gradle.kts`."
+            )
+
+    tasks.named<Jar>("jar") {
+        manifest {
+            attributes(mapOf("Automatic-Module-Name" to automaticModuleName))
+        }
+    }
+}
+
 val gpgSigningKey: Provider<String> = providers.environmentVariable("GPG_SIGNING_KEY")
 val gpgSigningKeyId: Provider<String> = providers.environmentVariable("GPG_SIGNING_KEY_ID")
 val gpgSigningPassword: Provider<String> = providers.environmentVariable("GPG_SIGNING_PASSWORD")


### PR DESCRIPTION
The jars released to Maven Central carry no `Automatic-Module-Name`, so a consumer putting them on the module path gets a module name derived from the jar's file name. That name is unstable (it changes with the artifact id) and it isn't ours to choose, which also blocks anyone from writing a `requires` clause they can rely on.

This sets the attribute on all nine published jars. Each name is the root package of the module carrying it, so a future `module-info.java` can declare the very same name:

| artifact | Automatic-Module-Name |
|---|---|
| `anthropic-java` | `com.anthropic.all` |
| `anthropic-java-core` | `com.anthropic` |
| `anthropic-java-client-okhttp` | `com.anthropic.client.okhttp` |
| `anthropic-java-aws` | `com.anthropic.aws` |
| `anthropic-java-bedrock` | `com.anthropic.bedrock` |
| `anthropic-java-foundry` | `com.anthropic.foundry` |
| `anthropic-java-google-cloud` | `com.anthropic.googlecloud` |
| `anthropic-java-mcp` | `com.anthropic.mcp` |
| `anthropic-java-vertex` | `com.anthropic.vertex` |

`anthropic-java-core` takes `com.anthropic` outright since it owns every package under it. `anthropic-java` ships no classes of its own — it only re-exports core and client-okhttp — so it has no root package to be named after and sits beside them instead.

### Implementation

The names live in a single map in the publish convention plugin, which applies to exactly the modules that are released; `anthropic-java-example`, `anthropic-java-detekt-rules` and `anthropic-java-ecosystem-test` don't apply it and are untouched. A published module missing from the map fails configuration rather than falling back to a derived name — the name is a compatibility promise that can't be changed after a release, so it should be a deliberate choice made once, before that module's first publish. The sources and javadoc jars deliberately get no attribute.

### Verification

On JDK 25, after `./gradlew jar`:

- every published jar's manifest carries the attribute, and the unpublished ones carry none;
- `jar --describe-module` reports each expected name, e.g. `com.anthropic@2.54.0 automatic` (the version still comes from the file name, as for any automatic module);
- all nine resolve together on one `--module-path` with `--add-modules ALL-MODULE-PATH`, so no two of them split a package. `com.anthropic.client` (core) and `com.anthropic.client.okhttp` are distinct packages, which is what makes that pair safe.

### Note on the naming

Module names can't be changed after they're released without breaking every `requires` clause that names them, so the scheme is worth a look before merge. The alternative considered was giving `com.anthropic` to the `anthropic-java` umbrella (the artifact the README recommends) and `com.anthropic.core` to core; that avoids the invented `.all` segment, but leaves `com.anthropic.core` shipping `com.anthropic.models`, `com.anthropic.services` and friends, so the module name would not be a prefix of its own packages. Happy to switch if you'd rather have it the other way.
