### PR TITLE
chore(docs): use HTTPS for MCP example server URL

### DIFF
--- a/anthropic-java-example/src/main/java/com/anthropic/example/MessagesMcpExample.java
+++ b/anthropic-java-example/src/main/java/com/anthropic/example/MessagesMcpExample.java
@@ -25,7 +25,7 @@ public final class MessagesMcpExample {
                 .build();
 
         BetaRequestMcpServerUrlDefinition mcpServer = BetaRequestMcpServerUrlDefinition.builder()
-                .url("http://example-server.modelcontextprotocol.io/sse")
+                .url("https://example-server.modelcontextprotocol.io/sse")
                 .name("example")
                 .toolConfiguration(toolConfiguration)
                 .build();


### PR DESCRIPTION
The MCP example uses an `http://` server URL, but remote MCP server URLs require HTTPS.

Update the example URL to use `https://`.