### PR TITLE
fix(bedrock): drop SSE frames with no "type" instead of silently truncating the stream

### DIFF
--- a/anthropic-java-bedrock/src/main/kotlin/com/anthropic/bedrock/backends/BedrockBackend.kt
+++ b/anthropic-java-bedrock/src/main/kotlin/com/anthropic/bedrock/backends/BedrockBackend.kt
@@ -363,7 +363,14 @@ private constructor(
                                         jsonMapper.readTree(message.payload).get("bytes").asText()
                                     )
                             )
-                        val sseEventType = jsonMapper.readTree(sseJson).get("type").asText()
+                        // AWS Bedrock appends a trailing `amazon-bedrock-invocationMetrics`
+                        // object to a Messages API stream that carries no "type" field. There
+                        // is no SSE event name to give a frame like that, so drop it rather
+                        // than fail the whole stream (matching the behavior of the other
+                        // Anthropic SDKs).
+                        val sseEventType =
+                            jsonMapper.readTree(sseJson).get("type")?.asText()
+                                ?: return@MessageDecoder
 
                         output.write("event: $sseEventType\ndata: $sseJson\n\n".toByteArray())
                         output.flush()

--- a/anthropic-java-bedrock/src/test/kotlin/com/anthropic/bedrock/backends/BedrockBackendTest.kt
+++ b/anthropic-java-bedrock/src/test/kotlin/com/anthropic/bedrock/backends/BedrockBackendTest.kt
@@ -1,18 +1,23 @@
 package com.anthropic.bedrock.backends
 
+import com.anthropic.core.http.Headers
 import com.anthropic.core.http.HttpMethod
 import com.anthropic.core.http.HttpRequest
 import com.anthropic.core.http.HttpRequestBody
+import com.anthropic.core.http.HttpResponse
 import com.anthropic.core.http.bodyToJson
 import com.anthropic.core.http.json
 import com.anthropic.core.jsonMapper
 import com.anthropic.errors.AnthropicException
 import com.anthropic.errors.AnthropicInvalidDataException
 import com.fasterxml.jackson.databind.node.ObjectNode
+import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
+import java.io.InputStream
 import java.io.OutputStream
 import java.lang.System.clearProperty
 import java.lang.System.setProperty
+import java.util.Base64
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatNoException
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -27,6 +32,8 @@ import software.amazon.awssdk.auth.credentials.AwsSessionCredentials
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain
+import software.amazon.eventstream.HeaderValue
+import software.amazon.eventstream.Message
 
 @ResourceLock("environment")
 internal class BedrockBackendTest {
@@ -945,6 +952,81 @@ internal class BedrockBackendTest {
         val backend = BedrockBackend.fromEnv()
 
         assertThatNoException().isThrownBy { backend.close() }
+    }
+
+    @Test
+    fun prepareResponseSkipsInvocationMetricsTrailerWithoutTypeField() {
+        val backend = BedrockBackend.builder().apiKey(API_KEY).region(Region.EU_WEST_1).build()
+
+        val firstEvent =
+            """{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}"""
+        // The trailer that AWS Bedrock appends to a Messages API stream. It carries usage
+        // metrics and, unlike every other frame in the stream, has no "type" field.
+        val invocationMetricsTrailer =
+            """{"amazon-bedrock-invocationMetrics":{"inputTokenCount":10,"outputTokenCount":20,"invocationLatency":543,"firstByteLatency":123}}"""
+        val secondEvent = """{"type":"content_block_stop","index":0}"""
+
+        val response = eventStreamResponse(firstEvent, invocationMetricsTrailer, secondEvent)
+        val prepared = backend.prepareResponse(response)
+        val sse = String(prepared.body().readBytes())
+
+        // Before the fix, parsing the trailer's absent "type" field throws an uncaught
+        // NullPointerException on the background SSE-decoding thread. The `use { }` blocks in
+        // `prepareResponse` still close the piped output from their `finally` clause when that
+        // happens, so the reader just sees a clean, early EOF: the stream silently truncates
+        // after `firstEvent` and `secondEvent` is lost, with no exception visible anywhere the
+        // caller could catch it. Asserting on the output (not on a thrown exception) is what
+        // actually catches that truncation - a naive try/catch around this call would pass
+        // against the buggy code too, since the failure never leaves the background thread.
+        assertThat(sse).contains("event: content_block_delta\ndata: $firstEvent\n\n")
+        assertThat(sse).contains("event: content_block_stop\ndata: $secondEvent\n\n")
+        assertThat(sse).doesNotContain("amazon-bedrock-invocationMetrics")
+    }
+
+    @Test
+    fun prepareResponseLeavesWellFormedEventUnchanged() {
+        val backend = BedrockBackend.builder().apiKey(API_KEY).region(Region.EU_WEST_1).build()
+        val event = """{"type":"message_stop"}"""
+
+        val prepared = backend.prepareResponse(eventStreamResponse(event))
+        val sse = String(prepared.body().readBytes())
+
+        assertThat(sse).isEqualTo("event: message_stop\ndata: $event\n\n")
+    }
+
+    /**
+     * Builds a fake response whose body is a binary AWS EventStream encoding one message per given
+     * JSON string, each wrapping its JSON as the base64 "bytes" field of an EventStream payload,
+     * mirroring the shape Bedrock sends for streamed Messages API responses.
+     */
+    private fun eventStreamResponse(vararg innerJsonPayloads: String): HttpResponse {
+        val body = ByteArrayOutputStream()
+        innerJsonPayloads.forEach { body.write(encodeEventStreamMessage(it)) }
+        val bodyBytes = body.toByteArray()
+
+        return object : HttpResponse {
+            override fun statusCode(): Int = 200
+
+            override fun headers(): Headers =
+                Headers.builder()
+                    .put("content-type", "application/vnd.amazon.eventstream")
+                    .put("x-amzn-bedrock-content-type", "application/json")
+                    .build()
+
+            override fun body(): InputStream = ByteArrayInputStream(bodyBytes)
+
+            override fun close() {}
+        }
+    }
+
+    /** Encodes [innerJson] as the payload of a single binary AWS EventStream message. */
+    private fun encodeEventStreamMessage(innerJson: String): ByteArray {
+        val base64Payload = Base64.getEncoder().encodeToString(innerJson.toByteArray())
+        val payloadJson = """{"bytes":"$base64Payload"}"""
+        val message = Message(emptyMap<String, HeaderValue>(), payloadJson.toByteArray())
+        val out = ByteArrayOutputStream()
+        message.encode(out)
+        return out.toByteArray()
     }
 
     /**


### PR DESCRIPTION
## The bug

`BedrockBackend.prepareResponse` (`anthropic-java-bedrock/src/main/kotlin/com/anthropic/bedrock/backends/BedrockBackend.kt:350`) parses the `"type"` field out of each decoded SSE frame like this:

```kotlin
val sseEventType = jsonMapper.readTree(sseJson).get("type").asText()
```

AWS Bedrock appends a trailing `amazon-bedrock-invocationMetrics` object to Messages API streaming responses. It carries usage metrics (input/output token counts, latency) and, unlike every other frame in the stream, has no `"type"` field. Jackson's `JsonNode.get(String)` returns Java `null` for a missing key. Kotlin sees that as a platform type, so there is no compile-time null check, and `.asText()` throws a `NullPointerException` at runtime.

## Why this is silent rather than a crash

The line runs inside a `MessageDecoder` callback, itself inside `sseThreadPool.execute { responseInput.use { pipedOutput.use { ... } } }`. The pool's `ThreadFactory` sets no `UncaughtExceptionHandler`, so the NPE prints to stderr on a `bedrock-sse-pipeline-N` thread and never reaches the caller. Kotlin's `use { }` closes `pipedOutput` in its `finally` regardless of how the block exits, and that close is what signals EOF to the paired `pipedInput`, the stream handed back as the response body. So the caller sees a clean, early EOF. The stream truncates mid-response with no exception anywhere it could be caught.

## Every other Anthropic SDK already guards this

- Python (`src/anthropic/lib/bedrock/_stream_decoder.py:80-83`): `event_type = payload.get("type"); if not isinstance(event_type, str): ...`. Fixed in #1682, after #1647 reported it as intermittent production 500s surfaced through pydantic-ai.
- TypeScript (`packages/bedrock-sdk/src/core/streaming.ts:63-64`):
  ```ts
  const eventName = isObj(parsed) && typeof parsed['type'] === 'string' ? parsed['type'] : null;
  if (eventName != null) { ... }
  ```
  with the comment: *"Frames without a 'type' (e.g. gateway keep-alives) have no SSE event name to carry them; drop them rather than failing the stream."*
- Go (`bedrock/bedrock.go`): extracts the type with `gjson`, which returns an empty string when absent; the `ssestream.go` switch has no `case ""`, so it silently no-ops.

Java is the only one of the four without a guard. This PR brings it in line: drop the frame instead of crashing when `"type"` is absent, matching the TS/Go behavior exactly (skip, do not emit an SSE event with an empty name).

```kotlin
val sseEventType = jsonMapper.readTree(sseJson).get("type")?.asText() ?: return@MessageDecoder
```

## Tests

`BedrockBackendTest.kt` had zero coverage of `prepareResponse` before this PR. I added two tests that drive it:

- `prepareResponseSkipsInvocationMetricsTrailerWithoutTypeField` builds a real binary AWS EventStream body (using the `software.amazon.eventstream.Message` encoder the production code already depends on) containing a normal event, the `amazon-bedrock-invocationMetrics` trailer, and a second normal event, then asserts both normal events come through and the trailer text never appears in the output.
- `prepareResponseLeavesWellFormedEventUnchanged` is a plain regression check that a normal event with a valid `"type"` is untouched.

The failure here happens on a background thread and gets swallowed, so a naive `assertThatThrownBy` test would pass against the buggy code and prove nothing. Both tests assert on the actual SSE output instead. RED before the fix looks like the first event coming through and the second one silently missing, which is exactly the truncation bug, not an exception.

RED (before the fix, `?: return@MessageDecoder` reverted back to `.get("type").asText()`):

```
Exception in thread "bedrock-sse-pipeline-0" java.lang.NullPointerException: Cannot invoke "com.fasterxml.jackson.databind.JsonNode.asText()" because the return value of "com.fasterxml.jackson.databind.JsonNode.get(String)" is null
	at com.anthropic.bedrock.backends.BedrockBackend.prepareResponse$lambda$0$0$0$0(BedrockBackend.kt:350)
	at software.amazon.eventstream.MessageDecoder.feed(MessageDecoder.java:137)
	...

BedrockBackendTest > prepareResponseSkipsInvocationMetricsTrailerWithoutTypeField() FAILED
    java.lang.AssertionError:
    Expecting actual:
      "event: content_block_delta
    data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}

    "
    to contain:
      "event: content_block_stop
    data: {"type":"content_block_stop","index":0}

    "
46 tests completed, 1 failed, 2 skipped
```

GREEN (with the fix): `BUILD SUCCESSFUL`, all tests pass, 0 failures.

I reverted the source fix after seeing GREEN to confirm the test goes back RED against the original code (same failure as above), then restored the fix.

## What I ran, and what I didn't

I ran `:anthropic-java-bedrock:test`, `:anthropic-java-bedrock:lintKotlin`, and `:anthropic-java-bedrock:detektMain`/`detektTest` (both clean, 0 code smells) with a JDK 21 toolchain. I did not run the full root `./gradlew build` across every module (AWS/GCP/Vertex/foundry/etc.). The bedrock module and its dependencies (`core`, `client-okhttp`, `aws`) are what this change touches, and running that scope directly kept the loop fast. I can run the full build if CI or a maintainer wants it before merge.

I did not touch the `sseThreadPool`'s missing `UncaughtExceptionHandler`. That is a real gap (it is why this bug was silent instead of loud) but it is a separate concern from the parsing bug itself, and fixing it does not change whether Bedrock's own keep-alive/metrics frames should be dropped. I can open a follow-up if that is wanted.

## Dedupe check

Checked both currently open PRs before filing:
- #390 (release: 2.57.1) also touches `BedrockBackend.kt` and `BedrockBackendTest.kt`, but only for an unrelated `anthropic_beta` header-to-body fix around lines 196-226 of the prepare-request path, plus new tests around line 599-671. It does not touch `prepareResponse` or line ~350 at all.
- #386 (Automatic-Module-Name) only touches `buildSrc/src/main/kotlin/anthropic.publish.gradle.kts`.

No overlap with either.
