### PR TITLE
docs(changelog): detail the beta files/skills GA-shape change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,12 @@ Full Changelog: [v2.58.0...v2.59.0](https://github.com/anthropics/anthropic-sdk-
 
 * **api:** beta files/skills namespaces use GA shapes; drop dated beta header pins ([e4e0e25](https://github.com/anthropics/anthropic-sdk-java/commit/e4e0e25fec796e85210995c8f69b4ed69015e0ef))
 
-  The beta Files and Skills namespaces no longer send the `files-api-2025-04-14` / `skills-2025-10-02` headers and return the same shapes as `client.files` / `client.skills` (with `Beta`-prefixed type names). Requests that still send those headers on raw HTTP keep receiving the beta shapes.
+  The beta Files and Skills services (`client.beta().files()`, `client.beta().skills()`) no longer send the `files-api-2025-04-14` / `skills-2025-10-02` headers and return the same shapes as `client.files()` / `client.skills()` (with `Beta`-prefixed model class names). Requests that still send those headers on raw HTTP keep receiving the beta shapes.
 
-  Changes in the beta namespaces:
-  - `client.beta.skills.delete()` now deletes a Skill together with all of its versions (previously refused while any version existed).
-  - Beta Messages type `BetaSkill` (container skill reference, `{type, skill_id, version}`) is renamed `BetaContainerSkill`; `BetaSkill` now names the Skills resource.
-  - `client.beta.files.list()` returns `{data, next_page}` and paginates with `page` / `ids` (was `{data, has_more, first_id, last_id}` with `before_id` / `after_id`); Skills types use `display_name`, `latest_version_id`, and `skver_…` version ids.
+  Changes in the beta services:
+  - `client.beta().skills().delete(...)` now deletes a Skill together with all of its versions (previously refused while any version existed). It returns `BetaDeletedSkill` (was `SkillDeleteResponse`).
+  - Beta Messages class `com.anthropic.models.beta.messages.BetaSkill` (container skill reference with `skillId()`, `type()`, `version()`) is renamed `BetaContainerSkill`. `BetaSkill` now names the Skill object `com.anthropic.models.beta.skills.BetaSkill` returned by `create` / `retrieve` / `list` (replacing `SkillCreateResponse` / `SkillRetrieveResponse` / `SkillListResponse`), and skill versions are `BetaSkillVersion` / `BetaDeletedSkillVersion` (replacing `Version*Response`).
+  - `client.beta().files().list()` returns a `FileListPage` over a `FileListPageResponse` with `data()` and `nextPage()`, and `FileListParams` paginates with `page()` / `ids()` (was `hasMore()`, `firstId()`, `lastId()` on both the page and the response, with `beforeId()` / `afterId()`); `autoPager()` is unchanged, and `SkillListPageResponse` / `VersionListPageResponse` drop `hasMore()`. `BetaSkill` uses `displayName()` (was `displayTitle()`, also on `SkillCreateParams`) and `latestVersionId()` (was `latestVersion()`), and `BetaSkillVersion` is addressed by its `skver_…` `id()` (the Unix-timestamp `version()` field is gone).
 
   Migration guides: [Migrate from `files-api-2025-04-14`](https://platform.claude.com/docs/en/build-with-claude/files#migrate-from-files-api-2025-04-14) · [Migrate from `skills-2025-10-02`](https://platform.claude.com/docs/en/build-with-claude/skills-guide#migrate-from-skills-2025-10-02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ Full Changelog: [v2.58.0...v2.59.0](https://github.com/anthropics/anthropic-sdk-
 
 * **api:** beta files/skills namespaces use GA shapes; drop dated beta header pins ([e4e0e25](https://github.com/anthropics/anthropic-sdk-java/commit/e4e0e25fec796e85210995c8f69b4ed69015e0ef))
 
+  The beta Files and Skills namespaces no longer send the `files-api-2025-04-14` / `skills-2025-10-02` headers and return the same shapes as `client.files` / `client.skills` (with `Beta`-prefixed type names). Requests that still send those headers on raw HTTP keep receiving the beta shapes.
+
+  Changes in the beta namespaces:
+  - `client.beta.skills.delete()` now deletes a Skill together with all of its versions (previously refused while any version existed).
+  - Beta Messages type `BetaSkill` (container skill reference, `{type, skill_id, version}`) is renamed `BetaContainerSkill`; `BetaSkill` now names the Skills resource.
+  - `client.beta.files.list()` returns `{data, next_page}` and paginates with `page` / `ids` (was `{data, has_more, first_id, last_id}` with `before_id` / `after_id`); Skills types use `display_name`, `latest_version_id`, and `skver_…` version ids.
+
+  Migration guides: [Migrate from `files-api-2025-04-14`](https://platform.claude.com/docs/en/build-with-claude/files#migrate-from-files-api-2025-04-14) · [Migrate from `skills-2025-10-02`](https://platform.claude.com/docs/en/build-with-claude/skills-guide#migrate-from-skills-2025-10-02)
+
 
 ### Bug Fixes
 


### PR DESCRIPTION
Expands the `beta files/skills namespaces use GA shapes; drop dated beta header pins` changelog entry with what changed in the beta namespaces and links to the migration guides.